### PR TITLE
feat: port v17 styling to v16 production

### DIFF
--- a/website_freemoov/__manifest__.py
+++ b/website_freemoov/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Website Freemoov',
     'category': 'Website',
-    'version': '16.0.0.0.8',
+    'version': '16.0.0.1.0',
     'summary': 'Website Freemoov',
     'author': '',
     'website' : '',

--- a/website_freemoov/__manifest__.py
+++ b/website_freemoov/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Website Freemoov',
     'category': 'Website',
-    'version': '16.0.0.0.7',
+    'version': '16.0.0.0.8',
     'summary': 'Website Freemoov',
     'author': '',
     'website' : '',

--- a/website_freemoov/migrations/16.0.0.1.0/post-migrate.py
+++ b/website_freemoov/migrations/16.0.0.1.0/post-migrate.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+import logging
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Clear asset cache after SCSS changes (shop card improvements)."""
+    _logger.info("Clearing asset cache for shop SCSS updates...")
+    cr.execute("DELETE FROM ir_attachment WHERE url LIKE '/web/assets/%'")
+    _logger.info("Asset cache cleared.")

--- a/website_freemoov/models/product.py
+++ b/website_freemoov/models/product.py
@@ -35,7 +35,8 @@ class ProductTemplate(models.Model):
 
 class ProductCategoryTemplate(models.Model):
 	_inherit = "product.public.category"
-	
+
 	# category_ids = fields.Many2many('product.public.category',string="Categories")
 	brand_ids = fields.Many2many('ust.product.brand',string="Brand")
 	category_description = fields.Text(string="Category Description ")
+	category_bottom_content = fields.Html(string="Category Bottom Content", translate=html_translate, sanitize=False)

--- a/website_freemoov/static/src/js/common.js
+++ b/website_freemoov/static/src/js/common.js
@@ -1,43 +1,105 @@
+odoo.define('website_freemoov.carousel_override', function (require) {
+    "use strict";
+    var publicWidget = require('web.public.widget');
+
+    // Override Odoo's product carousel widget:
+    // - Update sticky top on parent based on fixed header height
+    // - Disable _onMouseWheel (scroll should scroll the page, not cycle slides)
+    if (publicWidget.registry.websiteSaleCarouselProduct) {
+        publicWidget.registry.websiteSaleCarouselProduct.include({
+            _updateCarouselPosition: function () {
+                var size = 5;
+                var header = document.querySelector('header.o_header_affixed');
+                if (header) {
+                    size += $(header).outerHeight();
+                } else {
+                    document.querySelectorAll('.o_top_fixed_element').forEach(function (el) {
+                        size += $(el).outerHeight();
+                    });
+                }
+                var parent = this.$el.closest('.o_wsale_product_images')[0];
+                if (parent) {
+                    parent.style.setProperty('top', size + 'px');
+                }
+            },
+            _onMouseWheel: function () {
+                // No-op: let page scroll normally
+            },
+        });
+    }
+});
+
 $(document).ready(function(){
     $(".nav-item.dropdown.position-static").on('click', function(event) {
         $(this).closest('.dropdown-menu.o_mega_menu').modal('show');
-    })
+    });
     if($('div').hasClass('cat-div')) {
-        $('.cat-div').parent().find('#ust_all_in_one_configure').addClass('bg-white')
-      }
+        $('.cat-div').parent().find('#ust_all_in_one_configure').addClass('bg-white');
+    }
+
+    // Owl Carousel initialization (with .length guards)
+    if ($('.client').length) {
+        $('.client').owlCarousel({
+            loop: true,
+            margin: 10,
+            nav: true,
+            responsive: {
+                0: { items: 1.3 },
+                600: { items: 3 },
+                1000: { items: 4 }
+            }
+        });
+    }
+
+    if ($('.accessory_product').length) {
+        $('.accessory_product').owlCarousel({
+            loop: true,
+            margin: 10,
+            nav: true,
+            responsive: {
+                0: { items: 2.3 },
+                600: { items: 3 },
+                1000: { items: 5 }
+            }
+        });
+    }
+
+    // Replace download button with share button on product page
+    var $downloadBtn = $('.download_product_img');
+    if ($downloadBtn.length) {
+        var $shareBtn = $(
+            '<div class="share_product_link">' +
+                '<a class="share_link_btn" href="#" title="Copier le lien">' +
+                    '<i class="fa fa-share-alt"></i>' +
+                '</a>' +
+                '<span class="share_tooltip">Lien copié !</span>' +
+            '</div>'
+        );
+        $downloadBtn.after($shareBtn);
+        $downloadBtn.hide();
+    }
+
+    $(document).on('click', '.share_link_btn', function(e) {
+        e.preventDefault();
+        var url = window.location.href;
+        var $tooltip = $(this).siblings('.share_tooltip');
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(url).then(function() {
+                $tooltip.addClass('show');
+                setTimeout(function() { $tooltip.removeClass('show'); }, 2000);
+            });
+        } else {
+            var $temp = $('<input>');
+            $('body').append($temp);
+            $temp.val(url).select();
+            document.execCommand('copy');
+            $temp.remove();
+            $tooltip.addClass('show');
+            setTimeout(function() { $tooltip.removeClass('show'); }, 2000);
+        }
+    });
 });
-$('.client').owlCarousel({
-    loop:true,
-    margin:10,
-    nav:true,
-    responsive:{
-        0:{
-            items:1.3
-        },
-        600:{
-            items:3
-        },
-        1000:{
-            items:4
-        }
-    }
-})
-$('.accessory_product').owlCarousel({
-    loop:true,
-    margin:10,
-    nav:true,
-    responsive:{
-        0:{
-            items:2.3
-        },
-        600:{
-            items:3
-        },
-        1000:{
-            items:5
-        }
-    }
-})
+
 odoo.define('website_freemoov.category_script', function (require) {
     "use strict";
 
@@ -46,9 +108,8 @@ odoo.define('website_freemoov.category_script', function (require) {
     var Widget = require('web.Widget');
 
     $(document).ready(function () {
-        $('#o_product_page_reviews_content').addClass('show')
+        $('#o_product_page_reviews_content').addClass('show');
         $(".ust-all-slider .owl-item").each(function () {
-            var priceContainer = $(this).find(".oe_price");
             if ($(this).find("del").length > 0) {
                 $(this).find('.oe_price').css('color', '#dc3545');
                 $(this).find('.oe_price').addClass('main_price');
@@ -61,39 +122,29 @@ odoo.define('website_freemoov.category_script', function (require) {
                 $(this).find('span.h6').css('color', '#000');
             }
         });
-        var triggerSecondClick = true;
         $(".back_to_menu").click(function() {
             $("#top-menu-collapse").modal("show");
             $("#top-menu-collapse-sub-category").modal("hide");
             $(".top_menu_sub_categ").modal("hide");
-        })
+        });
         $(".cat-div").parents('#ust_all_in_one_configure').css("background-color", "#fff");
         if($('div').hasClass('cat-div')) {
-            $('.cat-div').parent().find('#ust_all_in_one_configure').addClass('bg-white')
-          }
-        
-      
+            $('.cat-div').parent().find('#ust_all_in_one_configure').addClass('bg-white');
+        }
+
         $(".category-link").click(function (event) {
             event.preventDefault();
             var categoryId = $(this).data("category-id");
             var categoryName = $(this).data("category-name");
             ajax.jsonRpc('/fetch_subcategories', 'call', {category_id: categoryId})
                 .then(function (data) {
-                    // Populate the subcategory modal with data
-                    console.log('>>>>>>>>>categoryId>>>>>>>>>>',data['sub_catg'])                    // $("#subcategoryModalTitle").text(categoryName);
-                    var category_html = "<a class='nav_link text-white' href='/shop/category/" + data['category'] + "'>" + categoryName + "</a>"  
+                    var category_html = "<a class='nav_link text-white' href='/shop/category/" + data['category'] + "'>" + categoryName + "</a>";
                     $("#subcategoryModalTitle").find('a').html(category_html);
-                    var link = "/shop/category/" + data['category']
-                    $(".sub_categ_button").find('a').attr('href',link);
+                    var link = "/shop/category/" + data['category'];
+                    $(".sub_categ_button").find('a').attr('href', link);
                     $("#subcategoryModalBody").html(data['sub_catg']);
-                            
                     $("#top-menu-collapse-sub-category").modal("show");
-
-                    
                 });
         });
     });
 });
-
-
-

--- a/website_freemoov/static/src/js/common.js
+++ b/website_freemoov/static/src/js/common.js
@@ -1,25 +1,21 @@
 odoo.define('website_freemoov.carousel_override', function (require) {
     "use strict";
     var publicWidget = require('web.public.widget');
+    var dom = require('web.dom');
 
     // Override Odoo's product carousel widget:
-    // - Update sticky top on parent based on fixed header height
+    // - Move sticky from #o-carousel-product to parent .o_wsale_product_images
+    // - Use Odoo's dom.scrollFixedOffset() for reliable header height detection
     // - Disable _onMouseWheel (scroll should scroll the page, not cycle slides)
     if (publicWidget.registry.websiteSaleCarouselProduct) {
         publicWidget.registry.websiteSaleCarouselProduct.include({
             _updateCarouselPosition: function () {
-                var size = 5;
-                var header = document.querySelector('header.o_header_affixed');
-                if (header) {
-                    size += $(header).outerHeight();
-                } else {
-                    document.querySelectorAll('.o_top_fixed_element').forEach(function (el) {
-                        size += $(el).outerHeight();
-                    });
-                }
+                // Use Odoo's built-in fixed offset calculation (handles all header states)
+                var offset = dom.scrollFixedOffset() + 5;
+                // Apply sticky top to the parent images container instead of the carousel
                 var parent = this.$el.closest('.o_wsale_product_images')[0];
                 if (parent) {
-                    parent.style.setProperty('top', size + 'px');
+                    parent.style.setProperty('top', offset + 'px');
                 }
             },
             _onMouseWheel: function () {

--- a/website_freemoov/static/src/scss/common.scss
+++ b/website_freemoov/static/src/scss/common.scss
@@ -49,19 +49,23 @@ a.btn {
         .oe_product_cart{
             height: 360px !important;
             .oe_product_image{
+                // Allow badge to be visible outside image area
+                overflow: visible !important;
                 .oe_product_image_link{
                     height: 160px !important;
+                    overflow: hidden;
                     img{
                         height: 160px !important;
                         object-fit: contain;
                     }
                 }
                 .ust-product-label{
+                    position: relative;
+                    z-index: 2;
                     .ust-main-prod-label{
                         span{
                             text-transform: capitalize;
                             border-radius: 15px !important;
-                            // background-color: #233E8D !important;
                             letter-spacing: 0.2px;
                         }
                     }

--- a/website_freemoov/static/src/scss/header.scss
+++ b/website_freemoov/static/src/scss/header.scss
@@ -1,3 +1,10 @@
+// Keep header always visible — prevent Odoo's hide-on-scroll-down animation
+header.o_header_standard {
+	&.o_header_affixed {
+		transform: translate(0, 0) !important;
+	}
+}
+
 .header_freemoov{
 	.btn_cta {
 		display: none;

--- a/website_freemoov/static/src/scss/product_detail.scss
+++ b/website_freemoov/static/src/scss/product_detail.scss
@@ -98,6 +98,37 @@
 	    padding: 45px;
 	    border-radius: 20px;
 	}
+	// Two-column layout: accordion left, stats right (desktop)
+	// Mobile: stats first, accordion second (via order classes)
+	.properties-layout {
+		align-items: flex-start;
+	}
+	.properties-stats-banner {
+		.propertie-box {
+			transition: transform 0.15s ease;
+			&:hover { transform: translateY(-2px); }
+			img {
+				max-height: 40px;
+				margin-bottom: 8px;
+			}
+			.name {
+				font-size: 12px;
+				color: #7F7F7F;
+			}
+			p.fw-bold {
+				font-size: 14px;
+			}
+		}
+	}
+	.properties-content-block {
+		.data {
+			margin-bottom: 16px;
+			p {
+				font-size: 14px;
+				line-height: 1.6;
+			}
+		}
+	}
 	.s_faq_collapse{
 		.accordion{
 			.card{
@@ -298,35 +329,218 @@
 		}
 	}
 }
-#product_detail{
-	#o-carousel-product{
-		position: unset !important;
-		.carousel-control-prev, .carousel-control-next{
-			opacity: 1;
-			span{
-				border: 0;
-				font-size: 24px;
-			}
+// ============================================================
+// PRODUCT DETAIL PAGE — Layout & Sticky
+// ============================================================
+
+// Force overflow visible on ALL ancestors up to #product_detail
+// Required for position:sticky to work
+#product_detail,
+#product_detail > .container,
+#product_detail > div > .container,
+#product_detail .row,
+#product_detail > div > .row {
+	overflow: visible !important;
+}
+
+// Force the main row to flex-start (Odoo sets align-items-center which breaks sticky)
+#product_detail {
+	// Override Odoo's align-items-center on the product row
+	> div > .row,
+	> .row,
+	.row.align-items-center {
+		align-items: flex-start !important;
+	}
+
+	// ============================================================
+	// LEFT COLUMN — Product Images (sticky on desktop)
+	// ============================================================
+	// Add padding-top so the image starts below the sticky header
+	padding-top: 16px;
+
+	.o_wsale_product_images {
+		// Desktop: sticky — top is set dynamically by JS based on header state
+		@media (min-width: 992px) {
+			position: sticky !important;
+			top: 5px; // Default; JS updates this when header becomes fixed
+			align-self: flex-start !important;
+			z-index: 2;
+			transition: top 200ms ease;
 		}
-		.carousel-control-prev{
-			span{
-				&:before{
-					content: "\f104";
+	}
+
+	// Remove extra whitespace below the carousel
+	#o-carousel-product {
+		// Override Odoo's o_carousel_product_left_indicators layout:
+		// Force column direction so indicators go BELOW the images, not beside them
+		flex-direction: column !important;
+		overflow: visible !important;
+		// Neutralize inner position-sticky (HTML class) — only parent .o_wsale_product_images should be sticky
+		position: relative !important;
+		// Neutralize inline top set by Odoo JS (_updateCarouselPosition) — causes jump
+		top: 0 !important;
+		// Kill Odoo core's "transition: top 200ms" that causes the jump animation
+		transition: none !important;
+		// Keep carousel below sticky header
+		z-index: 1;
+
+		.o_carousel_product_outer {
+			width: 100% !important;
+			// Override Odoo core's fixed height (400px / max-height: 90vh) that crops images
+			height: auto !important;
+			max-height: none !important;
+			order: 1;
+			overflow: visible !important;
+		}
+
+		// Let carousel height be driven by image content, not fixed h-100
+		.carousel-inner {
+			height: auto !important;
+			overflow: visible !important;
+			.carousel-item {
+				min-height: unset !important; // Override inline min-height: 605px
+				height: auto !important;
+				> div {
+					height: auto !important;
+					display: flex;
+					align-items: center;
+					justify-content: center;
+				}
+				img {
+					width: auto;
+					max-width: 100%;
+					height: auto !important;
+					max-height: none !important; // Override mh-100 (max-height:100%)
+					object-fit: contain;
+					margin: 0 auto;
 				}
 			}
 		}
-		.carousel-control-next{
-			span{
-				&:before{
-					content: "\f105";
-				}
+
+		// Carousel arrows: clean white circles
+		.carousel-control-prev, .carousel-control-next {
+			opacity: 1 !important;
+			width: 40px;
+			height: 40px;
+			top: 50%;
+			transform: translateY(-50%);
+			background: rgba(255, 255, 255, 0.85) !important;
+			background-image: none !important; // Kill any BS SVG icon
+			border-radius: 50%;
+			display: flex !important;
+			align-items: center;
+			justify-content: center;
+			box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+			transition: background-color 0.2s ease;
+			z-index: 5;
+			&:hover {
+				background: rgba(255, 255, 255, 1) !important;
+			}
+			// Hide ALL child elements (Odoo FA spans, BS icon spans, etc.)
+			> * {
+				display: none !important;
+				visibility: hidden !important;
+			}
+			// Clear any ::before pseudo-element from Odoo/BS
+			&::before {
+				display: none !important;
+				content: "" !important;
+			}
+			// Single custom arrow via ::after
+			&::after {
+				font-family: FontAwesome;
+				font-size: 18px;
+				color: #000;
+				display: block !important;
 			}
 		}
-		.o_carousel_product_indicators{
-			display: none;
+		.carousel-control-prev {
+			left: 12px;
+			&::after { content: "\f104"; }
+		}
+		.carousel-control-next {
+			right: 12px;
+			&::after { content: "\f105"; }
+		}
+
+		// ============================================================
+		// Thumbnail indicators → centered dots BELOW the image
+		// ============================================================
+		.o_carousel_product_indicators {
+			display: flex !important;
+			justify-content: center !important;
+			overflow: visible !important;
+			width: 100% !important;
+			padding: 12px 0 4px !important;
+			margin: 0 !important;
+			order: 2; // Place below the images
+			// Reset any Odoo positioning (left-side thumbnail layout)
+			position: relative !important;
+			bottom: auto !important;
+			left: auto !important;
+			right: auto !important;
+			top: auto !important;
+			transform: none !important;
+			text-align: center !important;
+			float: none !important;
+			flex: none !important; // Don't grow/shrink in flex context
+			max-width: 100% !important;
+			height: auto !important;
+
+			// The <ol> inside — override d-lg-block and inline justify-content:start
+			ol.carousel-indicators,
+			.carousel-indicators {
+				display: flex !important; // Override d-lg-block
+				justify-content: center !important; // Override inline style
+				align-items: center !important;
+				gap: 8px;
+				padding: 0 !important;
+				margin: 0 auto !important;
+				position: relative !important;
+				bottom: auto !important;
+				left: auto !important;
+				right: auto !important;
+				transform: none !important;
+				width: auto !important;
+				flex-wrap: wrap;
+				list-style: none;
+				text-align: center !important;
+
+				li, [data-bs-target] {
+					width: 10px !important;
+					height: 10px !important;
+					min-width: 10px !important;
+					min-height: 10px !important;
+					max-width: 10px !important;
+					max-height: 10px !important;
+					border-radius: 50% !important;
+					background-color: #BABABA !important;
+					opacity: 1 !important;
+					padding: 0 !important;
+					margin: 0 !important;
+					border: none !important;
+					cursor: pointer;
+					transition: background-color 0.2s ease;
+					text-indent: -9999px;
+					overflow: hidden;
+					float: none !important;
+					display: inline-block !important;
+
+					// Hide thumbnail images inside indicators
+					div, img, span {
+						display: none !important;
+					}
+					&.active {
+						background-color: #099D5D !important;
+					}
+				}
+			}
 		}
 	}
 	.breadcrumb{
+		position: relative;
+		z-index: 10;
+		margin-bottom: 16px !important;
 		li{
 			a, span{
 				font-size: 12px;
@@ -354,7 +568,8 @@
 	
 	#product_details{
 		h1{
-		    font-size: 28px;
+		    font-size: 26px;
+		    letter-spacing: -0.5px;
 		    margin-bottom: 20px;
 		    text-transform: uppercase;
 			font-style: italic;
@@ -416,59 +631,114 @@
 					}
 				}
 			}
-			.custom_product_list {
-				li span {
+			.trust-features {
+				display: grid;
+				grid-template-columns: 1fr 1fr;
+				gap: 10px;
+				margin-bottom: 20px;
+				padding: 16px;
+				background-color: #F5F6F7;
+				border-radius: 12px;
+				.trust-feature-item {
+					display: flex;
+					align-items: center;
+					gap: 8px;
 					font-size: 12px;
+					color: #333;
+					.fa {
+						font-size: 14px;
+						color: #099D5D;
+						width: 16px;
+						text-align: center;
+						flex-shrink: 0;
+					}
 				}
 			}
-			#o_wsale_cta_wrapper{
-				.css_quantity{
+			#o_wsale_cta_wrapper {
+				.css_quantity {
 					display: none !important;
 				}
-				#add_to_cart_wrap{
+				#add_to_cart_wrap {
 					width: 100%;
 					display: unset !important;
-					#add_to_cart{
-						width: 80%;
+					#add_to_cart {
+						width: 100%;
 						display: block;
-						padding: 15px 0;
-						background-image: linear-gradient(rgb(9, 157, 93), rgb(122, 193, 68));
+						padding: 16px 0;
+						background-image: linear-gradient(135deg, #099D5D, #7AC144);
+						font-size: 16px;
+						font-weight: 700;
+						letter-spacing: 0.5px;
+						text-transform: uppercase;
+						border-radius: 12px;
+						border: none;
+						transition: all 0.2s ease;
+						&:hover {
+							transform: translateY(-1px);
+							box-shadow: 0 4px 16px rgba(9,157,93,0.35);
+						}
 					}
-					.o_we_buy_now{
+					.o_we_buy_now {
 						display: none;
 					}
 				}
-				#product_option_block{
-					justify-content: center;
-					width: 80% !important;
-					.o_add_wishlist_dyn{
-						position: absolute;
-					    left: 60px;
-						top :67%;
-					    padding: 0;
-						.fa{
-							font-size: 24px;
-    						color: #000;
-						}
+			}
+			// Hide native product_option_block (moved to actions bar)
+			#product_option_block {
+				display: none !important;
+			}
+			// Hide native duplicate product tags (already shown as badges above)
+			.o_product_tags {
+				display: none !important;
+			}
+			// Unified actions bar: wishlist + compare + store
+			.product-actions-bar {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				width: 100%;
+				gap: 0;
+				margin-top: 16px;
+				padding-bottom: 16px;
+				border-bottom: 1px solid #eee;
+				.action-item {
+					display: flex;
+					flex-direction: column;
+					align-items: center;
+					gap: 4px;
+					flex: 1;
+					padding: 10px 8px;
+					background: none;
+					border: none;
+					border-right: 1px solid #eee;
+					color: #555;
+					font-size: 11px;
+					cursor: pointer;
+					text-decoration: none;
+					transition: color 0.2s ease;
+					&:last-child { border-right: none; }
+					&:hover { color: #099D5D; }
+					.fa {
+						font-size: 18px;
 					}
-					@media (max-width: 767.98px){
-						.o_add_wishlist_dyn{
-							left: 35px;
-					    	top: 30%;
-						}
+					// Wishlist button: reset Odoo's absolute positioning
+					&.o_add_wishlist_dyn {
+						position: relative !important;
+						left: auto !important;
+						top: auto !important;
+						width: auto !important;
+						height: auto !important;
+						opacity: 1 !important;
+						transform: none !important;
+						&:hover { color: #dc3545 !important; }
 					}
-				}
-				.compare-box{
-					width: 85%;
-					span{
-						font-size: 14px;
-					}				
 				}
 			}
 			.product_price{
 				h3{
-					font-size: 24px;
-					font-weight: 700;
+					font-size: 28px;
+					font-weight: 900;
+					color: #000;
 				}
 			}
 			.label{
@@ -485,6 +755,7 @@
 				    border-radius: 50%;
 				    margin-right: 8px;
     			}
+				&.bg-primary { background-color: #099D5D !important; }
 			}
 			.text{
 				li{
@@ -497,21 +768,150 @@
 		.o_product_page_reviews_link{
 			display: none;
 		}
-		.custom-text{
-			.payment-method{
-				background-color: #F5F6F7;
-			    padding: 20px 0 20px 30px;
-			    border-radius: 10px;
-			    margin: 32px 0;
+		// Hide Odoo native duplicate stock message (OWL component)
+		// Our custom .label already shows stock status
+		.availability_messages,
+		[id^="stock_freemoov_message"],
+		.css_not_available_msg,
+		.o_not_available_warn {
+			display: none !important;
+		}
+		// Hide native "Enregistrer pour plus tard" / "Save for later" button
+		.o_wsale_save_for_later_btn {
+			display: none !important;
+		}
+		// Hide native "Payer en plusieurs fois" since we have it in trust-block
+		#o_product_terms_and_share {
+			display: none;
+		}
+		// Override Odoo's native wishlist button positioning
+		// Odoo might set position:absolute via JS on ALL .o_add_wishlist_dyn
+		.product-actions-bar .o_add_wishlist_dyn {
+			position: relative !important;
+			left: auto !important;
+			top: auto !important;
+			right: auto !important;
+			bottom: auto !important;
+			width: auto !important;
+			height: auto !important;
+			opacity: 1 !important;
+			visibility: visible !important;
+			transform: none !important;
+			display: flex !important;
+		}
+			.trust-block {
+			margin-top: 24px;
+			border-top: 1px solid #eee;
+			padding-top: 20px;
+
+			.trust-title {
+				font-size: 14px;
+				font-weight: 700;
+				text-transform: uppercase;
+				color: #000;
+				margin-bottom: 10px;
+				.fa { margin-right: 6px; color: #099D5D; }
 			}
-			.advantages{
-				ul{
-					li{
-						span{
-							font-size: 14px;
-						}
+
+			.installment-block {
+				padding: 14px 16px;
+				background-color: #F5F6F7;
+				border-radius: 12px;
+				margin-bottom: 16px;
+				.fa-credit-card { color: #099D5D; margin-right: 8px; }
+				p { font-size: 13px; color: #333; }
+				.installment-link {
+					color: #099D5D;
+					text-decoration: none;
+					&:hover { text-decoration: underline; }
+				}
+				.installment-note { font-size: 11px; color: #7F7F7F; margin-top: 4px; }
+			}
+
+			.payment-secure-block {
+				margin-bottom: 16px;
+				p { font-size: 13px; color: #555; }
+				.payment-logos { max-height: 32px; opacity: 0.85; }
+			}
+
+			.confidence-block {
+				margin-bottom: 16px;
+				.confidence-badges {
+					display: flex;
+					flex-direction: column;
+					gap: 8px;
+				}
+				.trust-badge-link {
+					display: flex;
+					align-items: center;
+					gap: 8px;
+					padding: 10px 14px;
+					background-color: #F5F6F7;
+					border-radius: 10px;
+					color: #333;
+					font-size: 13px;
+					font-weight: 600;
+					text-decoration: none;
+					transition: all 0.2s ease;
+					.fa-check { color: #099D5D; font-size: 12px; }
+					&:hover {
+						background-color: #eef9f3;
+						color: #099D5D;
 					}
 				}
+			}
+
+			.contact-block {
+				margin-bottom: 16px;
+				padding: 14px 16px;
+				background-color: #F5F6F7;
+				border-radius: 12px;
+				p { font-size: 13px; color: #555; }
+				.phone-number {
+					font-size: 20px;
+					font-weight: 700;
+					color: #099D5D;
+					text-decoration: none;
+					display: block;
+					margin-top: 4px;
+					&:hover { text-decoration: underline; }
+				}
+			}
+
+			.reviews-block {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				padding: 12px 16px;
+				background-color: #F5F6F7;
+				border-radius: 12px;
+				margin-bottom: 16px;
+				.reviews-score {
+					display: flex;
+					align-items: center;
+					gap: 8px;
+					.score {
+						font-size: 20px;
+						font-weight: 900;
+						color: #000;
+					}
+					.stars .fa { color: #f5a623; font-size: 14px; }
+					.reviews-label {
+						font-size: 12px;
+						color: #7F7F7F;
+					}
+				}
+				.reviews-link {
+					font-size: 12px;
+					color: #099D5D;
+					text-decoration: none;
+					font-weight: 600;
+					&:hover { text-decoration: underline; }
+				}
+			}
+
+			.about-block {
+				p { font-size: 13px; color: #555; line-height: 1.6; }
 			}
 		}
 	}
@@ -519,22 +919,42 @@
 		.top-line{
 			width: 100%;
 		}
-		.compare-box{
-			width: 100%!important;
-		}
 		#product_details{
+			h1{
+				font-size: 22px;
+			}
 			.js_product{
+				.trust-features {
+					grid-template-columns: 1fr;
+					gap: 8px;
+					padding: 12px;
+				}
 				#o_wsale_cta_wrapper{
 					#add_to_cart_wrap{
 						#add_to_cart{
 							width: 100%;
+							padding: 16px 0;
+							font-size: 16px;
 						}
 					}
 				}
+				.product-actions-bar {
+					gap: 0;
+					.action-item {
+						font-size: 10px;
+						padding: 8px 4px;
+						.fa { font-size: 16px; }
+					}
+				}
 			}
-			.custom-text{
-				.payment-method{
-					padding: 20px 0 20px 0px;
+			.trust-block {
+				.reviews-block {
+					flex-direction: column;
+					align-items: flex-start;
+					gap: 8px;
+				}
+				.contact-block .phone-number {
+					font-size: 18px;
 				}
 			}
 		}
@@ -573,20 +993,51 @@
     transform: translate(-50%, -50%);
 }
 .carousel_product_num {
-	position: absolute;
-    left: 50%;
-    bottom: auto;
-    background-color: #F5F6F7;
-    padding: 2px 17px;
-    border-radius: 20px;
+	display: none !important;
 }
 .download_product_img {
+	display: none;
+}
+.share_product_link {
 	position: absolute;
-    right: 60px;
-    bottom: auto;
-    color: #000;	
+    right: 16px;
+    bottom: 16px;
+    color: #000;
+    z-index: 5;
+    cursor: pointer;
 	a {
 		color: #000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 36px;
+		height: 36px;
+		background-color: #F5F6F7;
+		border-radius: 50%;
+		transition: background-color 0.2s ease;
+		&:hover {
+			background-color: #e8e9ea;
+		}
+	}
+	.share_tooltip {
+		position: absolute;
+		bottom: 100%;
+		right: 0;
+		background-color: #099D5D;
+		color: #fff;
+		padding: 4px 12px;
+		border-radius: 6px;
+		font-size: 12px;
+		white-space: nowrap;
+		opacity: 0;
+		transform: translateY(4px);
+		transition: opacity 0.3s ease, transform 0.3s ease;
+		pointer-events: none;
+		margin-bottom: 6px;
+		&.show {
+			opacity: 1;
+			transform: translateY(0);
+		}
 	}
 }
 .product_tags_block {
@@ -654,15 +1105,17 @@
 			display: none;
 		}
 	}
-	.download_product_img {
-		bottom: 2%;
+	.share_product_link, .download_product_img {
+		bottom: 8px;
+		right: 16px;
 	}
 	.s_btn.d-flex.align-items-center {
-		display: block !important;
+		display: flex !important;
+		justify-content: center;
 
 		a.btn {
 			position: relative;
-    		left: 37%;
+    		left: auto;
 		}
 	}
 	
@@ -678,11 +1131,41 @@
 		height: 348px !important;
 	}
 	.carousel_product_num {
-		left: 38%;
-    	bottom: 2%;
+		display: none !important;
 	}
-	#product_detail #o-carousel-product .carousel-control-prev, #product_detail #o-carousel-product .carousel-control-next {
-		opacity: 1;
+	#product_detail #o-carousel-product .carousel-control-prev,
+	#product_detail #o-carousel-product .carousel-control-next {
+		width: 32px;
+		height: 32px;
+		&::after { font-size: 14px; }
+	}
+	#product_detail #o-carousel-product .carousel-control-prev { left: 4px; }
+	#product_detail #o-carousel-product .carousel-control-next { right: 4px; }
+	#product_detail {
+		padding-top: 8px;
+		// Mobile: never sticky
+		.o_wsale_product_images {
+			position: relative !important;
+		}
+		// Mobile: indicators always visible + centered
+		#o-carousel-product .o_carousel_product_indicators {
+			display: flex !important;
+			justify-content: center !important;
+		}
+		#product_details {
+			.js_product {
+				#o_wsale_cta_wrapper {
+					#add_to_cart_wrap {
+						text-align: center;
+					}
+				}
+			}
+		}
+	}
+	.properties {
+		.bg-color {
+			padding: 20px;
+		}
 	}
 	.header_freemoov {
 		.search_bar_1 {
@@ -709,16 +1192,87 @@
 		}
 	}
 }
+/* ==========================================
+   Cart page + Cart popover styling
+   ========================================== */
 .oe_cart, #o_cart_summary {
 	.btn-secondary {
 		background-color: #099D5D !important;
 		color: #fff !important;
 	}
+	.btn-primary {
+		background-image: linear-gradient(135deg, #099D5D, #7AC144);
+		border: none;
+		border-radius: 10px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.3px;
+		&:hover {
+			transform: translateY(-1px);
+			box-shadow: 0 4px 12px rgba(9,157,93,0.3);
+		}
+	}
 }
+
+/* Cart page products */
+#cart_products {
+	.o_cart_product {
+		padding: 16px 0;
+		border-bottom: 1px solid #f0f0f0;
+		img.o_image_64_max {
+			border-radius: 10px;
+		}
+		h6 { font-weight: 700; }
+		.js_delete_product {
+			color: #dc3545;
+			font-size: 12px;
+			&:hover { text-decoration: underline; }
+		}
+		.css_quantity {
+			border-radius: 10px;
+			overflow: hidden;
+			.btn-link { color: #099D5D; }
+			.form-control {
+				border: 1px solid #e8e9ea;
+				text-align: center;
+			}
+		}
+	}
+}
+
+/* Cart summary card */
+.o_total_card {
+	border-radius: 16px !important;
+	border: none !important;
+	box-shadow: 0 2px 16px rgba(0,0,0,0.06);
+	overflow: hidden;
+	.card-body, .accordion-body {
+		padding: 20px;
+	}
+	#order_total {
+		.h4 { font-weight: 900; color: #000; }
+	}
+	a.btn-primary, a.a-submit, button.btn-primary {
+		background-image: linear-gradient(135deg, #099D5D, #7AC144) !important;
+		border: none !important;
+		border-radius: 10px !important;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.3px;
+		padding: 14px 24px;
+		transition: all 0.2s ease;
+		&:hover {
+			transform: translateY(-1px);
+			box-shadow: 0 4px 12px rgba(9,157,93,0.3);
+		}
+	}
+}
+
 #add_to_cart_button {
 	background-color: #099D5D !important;
 	color: #fff !important;
 }
+
 #products_grid:not(.o_wsale_layout_list) .o_wsale_products_grid_table_wrapper .oe_product .o_wsale_product_grid_wrapper {
 	.prod_desc_div {
 		display: none;

--- a/website_freemoov/static/src/scss/product_detail.scss
+++ b/website_freemoov/static/src/scss/product_detail.scss
@@ -98,12 +98,25 @@
 	    padding: 45px;
 	    border-radius: 20px;
 	}
-	// Two-column layout: accordion left, stats right (desktop)
-	// Mobile: stats first, accordion second (via order classes)
-	.properties-layout {
-		align-items: flex-start;
-	}
+	// Full-width stats banner at top
 	.properties-stats-banner {
+		padding-bottom: 24px;
+		margin-bottom: 24px;
+		border-bottom: 1px solid #e0e0e0;
+		.stats-grid {
+			display: grid;
+			grid-template-columns: repeat(6, 1fr);
+			gap: 16px;
+			// Tablet: 3 columns
+			@media (max-width: 991.98px) {
+				grid-template-columns: repeat(3, 1fr);
+			}
+			// Mobile: 2 columns
+			@media (max-width: 575.98px) {
+				grid-template-columns: repeat(2, 1fr);
+				gap: 12px;
+			}
+		}
 		.propertie-box {
 			transition: transform 0.15s ease;
 			&:hover { transform: translateY(-2px); }
@@ -120,12 +133,25 @@
 			}
 		}
 	}
+	// Full-width content below stats
 	.properties-content-block {
 		.data {
-			margin-bottom: 16px;
-			p {
-				font-size: 14px;
-				line-height: 1.6;
+			margin-bottom: 20px;
+			font-size: 14px;
+			line-height: 1.7;
+			color: #444;
+		}
+		// Accordion items in 2 columns on desktop
+		.accordion-grid {
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+			gap: 0 16px;
+			@media (max-width: 767.98px) {
+				grid-template-columns: 1fr;
+			}
+			// Modals should not be constrained by grid
+			.modal {
+				grid-column: 1 / -1;
 			}
 		}
 	}
@@ -359,10 +385,12 @@
 	padding-top: 16px;
 
 	.o_wsale_product_images {
-		// Desktop: sticky — top is set dynamically by JS based on header state
+		// Desktop: sticky — top is refined by JS via dom.scrollFixedOffset()
 		@media (min-width: 992px) {
 			position: sticky !important;
-			top: 5px; // Default; JS updates this when header becomes fixed
+			// Safe CSS fallback: header ~80px + green banner ~35px + margin 5px
+			// JS will override this with exact value once header is initialized
+			top: 120px;
 			align-self: flex-start !important;
 			z-index: 2;
 			transition: top 200ms ease;

--- a/website_freemoov/static/src/scss/shop.scss
+++ b/website_freemoov/static/src/scss/shop.scss
@@ -93,13 +93,18 @@
 		.oe_product{
 			.o_wsale_product_grid_wrapper{
 				height: auto !important;
-				min-height: 420px;
+				min-height: 480px;
 			}
 		    .oe_product_cart{
 		    	border: 0;
 		    	background: #fff;
 			    padding: 15px;
 			    border-radius: 20px;
+			    position: relative;
+			    transition: box-shadow 0.2s ease;
+			    &:hover {
+			    	box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+			    }
 			    .oe_product_image{
 			    	.oe_product_image_link{
 			    		img{
@@ -148,7 +153,66 @@
 				    		}
 			    		}
 			    		.product_variant{
-			    			display: none;
+			    			margin-top: 8px;
+			    			> .js_add_cart_variants:first-child {
+			    				display: grid;
+			    				grid-template-columns: 1fr 1fr;
+			    				gap: 4px;
+			    			}
+			    			.variant_attribute {
+			    				display: flex !important;
+			    				flex-direction: row !important;
+			    				justify-content: space-between !important;
+			    				align-items: center !important;
+			    				background: #f5f6f7;
+			    				border-radius: 6px;
+			    				padding: 5px 8px !important;
+			    				margin: 0 !important;
+			    				.attribute_name {
+			    					font-size: 9px;
+			    					font-weight: 600;
+			    					color: #888;
+			    					text-transform: uppercase;
+			    					margin: 0 !important;
+			    					white-space: nowrap;
+			    					overflow: hidden;
+			    					text-overflow: ellipsis;
+			    					max-width: 55%;
+			    					line-height: 1.3;
+			    					letter-spacing: 0.2px;
+			    				}
+			    				ul {
+			    					margin: 0 !important;
+			    					li {
+			    						margin: 0 !important;
+			    						label {
+			    							padding: 0 !important;
+			    							.form-check {
+			    								padding: 0;
+			    								margin: 0;
+			    								min-height: 0;
+			    								input { display: none; }
+			    								.radio_input_value {
+			    									padding: 0;
+			    									font-weight: 700;
+			    									font-size: 11px;
+			    									color: #222;
+			    								}
+			    							}
+			    						}
+			    					}
+			    				}
+			    				select {
+			    					font-weight: 700;
+			    					font-size: 11px;
+			    					border: 0;
+			    					background: transparent;
+			    					padding: 0;
+			    					color: #222;
+			    					-webkit-appearance: none;
+			    					appearance: none;
+			    				}
+			    			}
 			    		}
 			    	}
 			    	.o_wsale_product_sub{
@@ -167,11 +231,21 @@
 			    					align-items: baseline;
 			    					gap: 6px;
 			    					flex-wrap: wrap;
-			    					.price_current .h6{
-			    						font-weight: 700;
-			    						font-size: 16px;
-			    						color: #000;
-			    						margin-bottom: 0;
+			    					.price_current{
+			    						display: flex;
+			    						align-items: baseline;
+			    						gap: 4px;
+			    						.h6{
+			    							font-weight: 800;
+			    							font-size: 18px;
+			    							color: #000;
+			    							margin-bottom: 0;
+			    						}
+			    					}
+			    					small.text-muted {
+			    						font-size: 10px !important;
+			    						color: #999 !important;
+			    						font-weight: 500;
 			    					}
 			    					.price_original{
 			    						font-size: 12px;
@@ -217,7 +291,7 @@
 						    flex-wrap: wrap-reverse;
 						    justify-content: end;
 						    opacity: 1;
-						    width: 48%;
+						    width: auto;
 						    gap: 6px;
 						    .btn{
     							padding: 6px 8px;
@@ -230,8 +304,28 @@
     							color: #fff;
     						}
 						    .o_add_wishlist{
-    							border-color: #e0e0e0;
-    							order: 1;
+    							position: absolute !important;
+    							top: 12px;
+    							right: 12px;
+    							z-index: 3;
+    							border: none !important;
+    							background: rgba(255,255,255,0.95) !important;
+    							border-radius: 50% !important;
+    							width: 34px;
+    							height: 34px;
+    							padding: 0 !important;
+    							display: flex !important;
+    							align-items: center;
+    							justify-content: center;
+    							box-shadow: 0 1px 6px rgba(0,0,0,0.1);
+    							transition: all 0.2s ease;
+    							order: unset;
+    							&:hover {
+    								background: #fff !important;
+    								color: #dc3545 !important;
+    								box-shadow: 0 2px 10px rgba(220,53,69,0.2);
+    								transform: scale(1.1);
+    							}
     						}
 			    			.o_add_compare{
 			    				font-size: 12px;
@@ -272,6 +366,22 @@
 						.product_info h6 a {
 							font-size: 14px;
 						}
+						.product_variant {
+							> .js_add_cart_variants:first-child {
+								grid-template-columns: 1fr 1fr;
+								gap: 3px;
+							}
+							.variant_attribute {
+								padding: 4px 6px !important;
+								.attribute_name {
+									font-size: 8px;
+									max-width: 50%;
+								}
+								ul li label .form-check .radio_input_value {
+									font-size: 10px;
+								}
+							}
+						}
 					}
 					.o_wsale_product_sub{
 						flex-direction: column;
@@ -284,6 +394,12 @@
 							width: 100%;
 							justify-content: flex-start;
 							margin-top: 8px;
+							.o_add_wishlist {
+								top: 10px;
+								right: 10px;
+								width: 30px;
+								height: 30px;
+							}
 						}
 						.product_sub_detail{
 							width: 100%;
@@ -321,6 +437,7 @@
 				border: 0;
 				box-shadow: 0 1px 3px rgba(0,0,0,0.04);
 				transition: box-shadow 0.2s ease;
+				position: relative;
 				&:hover{
 					box-shadow: 0 4px 16px rgba(0,0,0,0.08);
 				}
@@ -460,6 +577,15 @@
 									align-items: baseline;
 									gap: 8px;
 									flex-wrap: wrap;
+									&::before {
+										content: "Prix :";
+										display: block;
+										width: 100%;
+										font-size: 11px;
+										color: #888;
+										font-weight: 500;
+										margin-bottom: -4px;
+									}
 									.price_current{
 										display: flex;
 										align-items: baseline;
@@ -471,6 +597,11 @@
 											margin-bottom: 0;
 											white-space: nowrap;
 										}
+									}
+									small.text-muted {
+										font-size: 11px !important;
+										color: #888 !important;
+										font-weight: 600;
 									}
 									.price_original{
 										font-size: 13px;
@@ -536,26 +667,41 @@
 								}
 							}
 							.o_add_wishlist{
-								border-color: #e0e0e0;
-								background: #fff;
-								padding: 9px 11px;
-								border-radius: 12px;
+								position: absolute !important;
+								top: 16px;
+								right: 16px;
+								z-index: 3;
+								border: none !important;
+								background: rgba(255,255,255,0.95) !important;
+								border-radius: 50% !important;
+								width: 38px;
+								height: 38px;
+								padding: 0 !important;
+								display: flex !important;
+								align-items: center;
+								justify-content: center;
+								box-shadow: 0 1px 6px rgba(0,0,0,0.1);
+								transition: all 0.2s ease;
 								color: #666;
-								transition: all 0.15s ease;
 								&:hover{
-									border-color: #dc3545;
-									color: #dc3545;
+									background: #fff !important;
+									color: #dc3545 !important;
+									box-shadow: 0 2px 10px rgba(220,53,69,0.2);
+									transform: scale(1.1);
 								}
 							}
 							.o_add_compare{
-								font-size: 12px;
-								color: #888;
-								padding: 0;
-								border: 0;
-								background: transparent;
+								font-size: 13px;
+								color: #666;
+								padding: 6px 14px !important;
+								border: 1px solid #e0e0e0 !important;
+								border-radius: 8px;
+								background: #fff;
 								white-space: nowrap;
+								transition: all 0.15s ease;
 								&:hover{
-									color: #000;
+									color: #099D5D;
+									border-color: #099D5D !important;
 								}
 							}
 						}
@@ -621,10 +767,11 @@
 								width: 100%;
 								flex-wrap: wrap;
 								gap: 8px;
-								.product_price{
-									flex-direction: row;
-									align-items: baseline;
-									gap: 8px;
+								.product_price .price_wrapper::before {
+									font-size: 10px;
+								}
+								.product_price .price_wrapper .price_current .h6 {
+									font-size: 20px;
 								}
 							}
 
@@ -638,6 +785,12 @@
 									font-size: 15px;
 									font-weight: 700;
 									border-radius: 10px;
+								}
+								.o_add_wishlist {
+									top: 12px;
+									right: 12px;
+									width: 34px;
+									height: 34px;
 								}
 								.o_add_compare{
 									display: none;

--- a/website_freemoov/static/src/scss/shop.scss
+++ b/website_freemoov/static/src/scss/shop.scss
@@ -31,6 +31,14 @@
 		}
 	}
 }
+// Prevent horizontal scroll on mobile (category cards overflowing)
+@media (max-width: 767px) {
+	.js_sale.o_wsale_products_page,
+	.oe_website_sale {
+		overflow-x: hidden !important;
+	}
+}
+
 .js_sale.o_wsale_products_page{
 	background-color: #F5F6F7;
 	.oe_website_sale{
@@ -84,7 +92,8 @@
 	.o_wsale_products_grid_table_wrapper{
 		.oe_product{
 			.o_wsale_product_grid_wrapper{
-				height: 455px !important;
+				height: auto !important;
+				min-height: 420px;
 			}
 		    .oe_product_cart{
 		    	border: 0;
@@ -93,12 +102,8 @@
 			    border-radius: 20px;
 			    .oe_product_image{
 			    	.oe_product_image_link{
-			    		span{
-			    			height: 160px !important;
-				    		img{
-				    			height: 160px !important;
-	    						width: 160px !important;
-				    		}
+			    		img{
+			    			object-fit: contain;
 			    		}
 			    	}
 		    	}
@@ -108,11 +113,20 @@
 			    			.ust-product-label{
 			    				margin-bottom: 8px;
 			    				.ust-main-prod-label{
+			    					display: inline-flex;
+			    					align-items: center;
+			    					gap: 4px;
+			    					flex-wrap: wrap;
 			    					span{
 			    						text-transform: capitalize;
     									border-radius: 6px !important;
-    									// background-color: #233E8D !important;
-										// border-color: #233E8D !important;
+    									font-size: 11px;
+    									padding: 3px 8px;
+    									white-space: nowrap;
+    									display: inline-block;
+    									max-width: 100%;
+    									overflow: hidden;
+    									text-overflow: ellipsis;
 			    					}
 			    				}
 			    			}
@@ -138,14 +152,63 @@
 			    		}
 			    	}
 			    	.o_wsale_product_sub{
-			    		.product_price{
-			    			.h6{
-			    				font-weight: 700;
-			    				font-size: 16px;
-								color: #dc3545;
-								
+			    		flex-wrap: wrap;
+			    		align-items: center;
+			    		gap: 8px;
+			    		.product_sub_detail{
+			    			display: flex;
+			    			align-items: center;
+			    			gap: 10px;
+			    			flex: 1;
+			    			order: 1;
+			    			.product_price{
+			    				.price_wrapper{
+			    					display: flex;
+			    					align-items: baseline;
+			    					gap: 6px;
+			    					flex-wrap: wrap;
+			    					.price_current .h6{
+			    						font-weight: 700;
+			    						font-size: 16px;
+			    						color: #000;
+			    						margin-bottom: 0;
+			    					}
+			    					.price_original{
+			    						font-size: 12px;
+			    						color: #999;
+			    						text-decoration: line-through;
+			    					}
+			    					&:has(.price_original) .price_current .h6{
+			    						color: #dc3545;
+			    					}
+			    				}
 			    			}
-							
+			    			.stock_badge{
+			    				display: inline-flex;
+			    				align-items: center;
+			    				font-size: 11px;
+			    				font-weight: 600;
+			    				white-space: nowrap;
+			    				padding: 3px 8px;
+			    				border-radius: 20px;
+			    				.stock_dot{
+			    					width: 7px;
+			    					height: 7px;
+			    					border-radius: 50%;
+			    					display: inline-block;
+			    					margin-right: 5px;
+			    				}
+			    				&.stock_available{
+			    					background-color: #ecfdf5;
+			    					color: #065f46;
+			    					.stock_dot{ background-color: #099D5D; }
+			    				}
+			    				&.stock_unavailable{
+			    					background-color: #fef2f2;
+			    					color: #991b1b;
+			    					.stock_dot{ background-color: #dc3545; }
+			    				}
+			    			}
 			    		}
 			    		.o_wsale_product_btn{
 			    			position: unset;
@@ -155,49 +218,29 @@
 						    justify-content: end;
 						    opacity: 1;
 						    width: 48%;
+						    gap: 6px;
 						    .btn{
     							padding: 6px 8px;
     							border-radius: 10px;
     						}
     						.a-submit{
     							order: 2;
+    							background-color: #099D5D;
+    							border-color: #099D5D;
+    							color: #fff;
     						}
 						    .o_add_wishlist{
-    							border-color: #000000;
+    							border-color: #e0e0e0;
     							order: 1;
-    							margin-right: 10px;
     						}
 			    			.o_add_compare{
 			    				font-size: 12px;
 			    				width: 100%;
 							    text-align: end;
-							    margin-bottom: 30px;
+							    margin-bottom: 10px;
 							    order: 3;
+							    color: #888;
 		    				}
-			    		}
-			    		.product_sub_detail{
-			    			width: 48%;
-			    			.label{
-			    				display: flex;
-			    				font-size: 12px;
-    							font-weight: 700;
-    							.o_ribbon_left, .o_ribbon_right{
-				    				position: unset;
-				    				padding: 0;
-	    							transform: unset;
-	    							width: 15px;
-								    height: 15px;
-								    display: inline-block;
-								    border-radius: 50%;
-								    margin-right: 8px;
-				    			}
-			    			}
-			    			.variant{
-			    				background-color: #F5F6F7;
-							    text-align: center;
-							    border-radius: 25px;
-							    font-size: 13px;
-			    			}
 			    		}
 			    	}
 			    }
@@ -208,13 +251,43 @@
 		.o_wsale_products_grid_table_wrapper{
 			.oe_product{
 				width: 100% !important;
+				.o_wsale_product_grid_wrapper{
+					height: auto !important;
+					min-height: 320px;
+					overflow: hidden;
+				}
+				.oe_product_cart{
+					padding: 12px;
+					overflow: hidden;
+				}
+			.oe_product_image{
+				.oe_product_image_link{
+					img{
+						object-fit: contain;
+					}
+				}
+			}
 				.o_wsale_product_information{
+					.o_wsale_product_information_text{
+						.product_info h6 a {
+							font-size: 14px;
+						}
+					}
 					.o_wsale_product_sub{
+						flex-direction: column;
+						align-items: flex-start;
 						.o_wsale_product_btn{
-							position: absolute;
-						    top: auto;
-						    bottom: calc(100% + 0.5rem);
-						    z-index: 2;
+							position: relative;
+							top: auto;
+							bottom: auto;
+							z-index: 2;
+							width: 100%;
+							justify-content: flex-start;
+							margin-top: 8px;
+						}
+						.product_sub_detail{
+							width: 100%;
+							margin-top: 8px;
 						}
 					}
 				}
@@ -226,193 +299,372 @@
 #products_grid.o_wsale_layout_list{
 	.o_wsale_products_grid_table_wrapper{
 		.oe_product{
-		    .oe_product_cart{
-			    padding: 20px;
-			    background-color: #fff;
-    			border-radius: 20px;
-    			border: 0;
-			    .o_wsale_product_information{
-		    		.brand {
-		    			margin-bottom: 4px;
-						font-size: 10px;
-						margin-top: 10px;
-		    		}
-			    	.o_wsale_product_information_text{
-			    		display: flex;
-			    		.product_info{
-			    			width: 50%;
-			    			.o_wsale_products_item_title {
-				    			margin-top: 4px;
-				    		}
-				    		h6{
-				    			font-size: 16px;
-				    			a{
-				    				text-transform: uppercase;
-								    color: #000000 !important;
-								    font-weight: 700;
+			// Larger product image in list view
+			.oe_product_image {
+				min-width: 200px;
+				width: 200px;
+				.oe_product_image_link {
+					display: flex;
+					align-items: center;
+					justify-content: center;
+					min-height: 180px;
+					img {
+						object-fit: contain;
+						max-height: 180px;
+					}
+				}
+			}
+			.oe_product_cart{
+				padding: 20px;
+				background-color: #fff;
+				border-radius: 16px;
+				border: 0;
+				box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+				transition: box-shadow 0.2s ease;
+				&:hover{
+					box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+				}
+
+				.o_wsale_product_information{
+					.brand {
+						margin-bottom: 2px;
+						font-size: 12px;
+						margin-top: 8px;
+						color: #666;
+						letter-spacing: 0.2px;
+						text-transform: uppercase;
+						font-weight: 600;
+					}
+
+					.o_wsale_product_information_text{
+						display: flex;
+						gap: 16px;
+
+						.product_info{
+							width: 45%;
+							flex-shrink: 0;
+							.ust-product-label{
+								margin-bottom: 6px;
+								.ust-main-prod-label span{
+									text-transform: capitalize;
+									border-radius: 6px !important;
+									font-size: 11px;
+									padding: 3px 10px;
+								}
+							}
+							.o_wsale_products_item_title {
+								margin-top: 2px;
+							}
+							h6{
+								font-size: 16px;
+								line-height: 1.35;
+								margin-bottom: 0;
+								a{
+									text-transform: uppercase;
+									color: #000 !important;
+									font-weight: 700;
 									font-style: italic;
-				    			}
-				    		}
-			    		}
-			    		.product_variant{
-			    			width: 50%;
-			    			.js_add_cart_variants{
-			    				.variant_attribute{
-    								border-bottom: 1px solid;
-    								padding: 6px 0;
-    								font-size: 14px;
-    								ul{
-    									li{
-    										margin-bottom: 0 !important;
-    										label{
-    											.form-check{
-    												padding: 0;
-    												input{
-    													display: none;
-    												}
-    											}
-    										}
-    									}
-    								}
-			    				}
-			    			}
-			    		}
-			    	}
-			    	.o_wsale_product_sub{
-			    		.product_price{
-			    			width: 40%;
-			    			order: 1;
-			    			.h6{
-			    				font-weight: 700;
-			    				font-size: 16px;
-			    			}
-							// del {
-							// 	color: #dc3545 !important;
-							// }
-			    		}
-			    		.o_wsale_product_btn{
-			    			order: 3;
-			    			width: 65%;
-			    			.btn{
-    							padding: 6px 8px;
-    							border-radius: 10px;
-    						}
-    						.a-submit{
-    							margin-left: 40px;
-    						}
-				    		.o_add_compare {
-								float: right;
-			    			}
-			    		}
-			    	}
-			    	.product_sub_detail{
-	    			    width: 30%;
-					    display: flex;
-					    justify-content: space-between;
-		    			.label{
-		    				display: flex;
-		    				font-size: 12px;
-							font-weight: 700;
-							margin-bottom: 0;
+									display: -webkit-box;
+									-webkit-line-clamp: 2;
+									-webkit-box-orient: vertical;
+									overflow: hidden;
+								}
+							}
+							.prod_desc_div,
+							.oe_subdescription{
+								display: none;
+							}
+						}
+
+						.product_variant{
+							width: 55%;
+							.js_add_cart_variants{
+								display: flex;
+								flex-direction: column;
+								gap: 0;
+								.variant_attribute{
+									display: flex !important;
+									flex-direction: row;
+									justify-content: space-between;
+									align-items: center !important;
+									background: none;
+									border-radius: 0;
+									padding: 10px 0;
+									border: 0;
+									border-bottom: 1px solid #e0e0e0;
+									margin: 0;
+									.attribute_name{
+										font-size: 12px;
+										font-weight: 700;
+										color: #333;
+										line-height: 1.3;
+										margin-bottom: 0;
+										letter-spacing: 0.5px;
+										text-transform: uppercase;
+									}
+									ul{
+										margin: 0 !important;
+										li{
+											margin: 0 !important;
+											label{
+												padding: 0 !important;
+												.form-check{
+													padding: 0;
+													margin: 0;
+													input{ display: none; }
+													.radio_input_value{
+														padding: 0;
+														font-weight: 600;
+														font-size: 14px;
+														color: #111;
+													}
+												}
+											}
+										}
+									}
+									select{
+										font-weight: 600;
+										font-size: 14px;
+										border: 0;
+										background: transparent;
+										padding: 0;
+										color: #111;
+									}
+								}
+							}
+						}
+					}
+
+					.o_wsale_product_sub{
+						display: flex;
+						flex-wrap: wrap;
+						align-items: center;
+						justify-content: flex-start;
+						margin-top: 14px;
+						padding-top: 14px;
+						border-top: 1px solid #f0f0f0;
+						gap: 12px;
+
+						.product_sub_detail{
+							display: flex;
+							align-items: center;
+							gap: 14px;
+							flex: 1;
+							min-width: 0;
+							order: 1;
+
+							.product_price{
+								order: 1;
+								.price_wrapper{
+									display: flex;
+									align-items: baseline;
+									gap: 8px;
+									flex-wrap: wrap;
+									.price_current{
+										display: flex;
+										align-items: baseline;
+										gap: 4px;
+										.h6{
+											font-weight: 900;
+											font-size: 24px;
+											color: #000;
+											margin-bottom: 0;
+											white-space: nowrap;
+										}
+									}
+									.price_original{
+										font-size: 13px;
+										color: #999;
+										text-decoration: line-through;
+									}
+									&:has(.price_original) .price_current .h6{
+										color: #dc3545;
+									}
+								}
+							}
+
+							.stock_badge{
+								display: inline-flex;
+								align-items: center;
+								font-size: 12px;
+								font-weight: 700;
+								white-space: nowrap;
+								padding: 4px 12px;
+								border-radius: 20px;
+								order: 2;
+								.stock_dot{
+									width: 8px;
+									height: 8px;
+									border-radius: 50%;
+									display: inline-block;
+									margin-right: 6px;
+									flex-shrink: 0;
+								}
+								&.stock_available{
+									background-color: #ecfdf5;
+									color: #065f46;
+									.stock_dot{ background-color: #099D5D; }
+								}
+								&.stock_unavailable{
+									background-color: #fef2f2;
+									color: #991b1b;
+									.stock_dot{ background-color: #dc3545; }
+								}
+							}
+						}
+
+						.o_wsale_product_btn{
+							display: flex;
+							align-items: center;
+							gap: 8px;
 							order: 2;
-							.o_ribbon_left, .o_ribbon_right{
-			    				position: unset;
-			    				padding: 0;
-    							transform: unset;
-    							width: 15px;
-							    height: 15px;
-							    display: inline-block;
-							    border-radius: 50%;
-							    margin-right: 8px;
-			    			}
-		    			}
-		    			.variant{
-		    				display: none;
-		    			}
-		    		}
-		    		.compare-button{
-		    			position: absolute;
-					    top: 40%;
-					    left: -112px;
-					    .btn{
-					    	font-size: 12px;
-					    }
-		    		}
-			    }
-		    }
+							flex-shrink: 0;
+
+							.a-submit{
+								background-image: linear-gradient(#099D5D, #7AC144);
+								color: #fff;
+								padding: 12px 28px;
+								border-radius: 10px;
+								font-weight: 600;
+								font-size: 15px;
+								letter-spacing: 0.3px;
+								transition: all 0.15s ease;
+								&:hover{
+									background-image: linear-gradient(darken(#099D5D, 5%), darken(#7AC144, 5%));
+									transform: translateY(-1px);
+									box-shadow: 0 4px 12px rgba(9,157,93,0.3);
+								}
+							}
+							.o_add_wishlist{
+								border-color: #e0e0e0;
+								background: #fff;
+								padding: 9px 11px;
+								border-radius: 12px;
+								color: #666;
+								transition: all 0.15s ease;
+								&:hover{
+									border-color: #dc3545;
+									color: #dc3545;
+								}
+							}
+							.o_add_compare{
+								font-size: 12px;
+								color: #888;
+								padding: 0;
+								border: 0;
+								background: transparent;
+								white-space: nowrap;
+								&:hover{
+									color: #000;
+								}
+							}
+						}
+					}
+
+					.compare-button{
+						display: none;
+					}
+				}
+			}
 		}
 	}
+
 	@media (max-width: 767.98px){
 		.o_wsale_products_grid_table_wrapper{
 			.oe_product{
-			    .oe_product_cart{
-			    	padding: 0px;
-				    .o_wsale_product_information{
-				    	padding-right: 0;
-				    	.o_wsale_product_information_text{
-				    		display: unset;
-				    		.product_info, .product_variant{
-				    			width: 100%;
-				    		}
-				    		.product_variant{
-				    			margin-bottom: 30px;
-		    					.js_add_cart_variants{
-			    					.variant_attribute{
-			    						justify-content: unset !important;
-	    								.radio_input_value:not(.o_variant_pills_input_value){
-	    									margin-right: 0px;
-	    								}
-		    						}
-	    						}
-    						}
-				    	}
-				    	.o_wsale_product_sub{
-				    		align-items: baseline !important;
-				    		.product_price{
-			    				order: 2;
-			    				margin-right: 30px;
-			    			}
-				    		.o_wsale_product_btn{
-			    				.o_add_compare{
-		    					   display: none;
-			    				}
-		    				}
-		    				.product_sub_detail{
-					    		width: 100%;
-					    		margin-left: -100px;
-					    		label{
-					    			
-					    			order: 1;
-					    		}
-					    	}
-				    	}
-			    	}
-		    	}
-	    	}
-    	}
-	}
-	@media (min-width: 768px) and (max-width: 991.98px){
-		.o_wsale_products_grid_table_wrapper{
-			.oe_product{
-			    .oe_product_cart{
-				    .o_wsale_product_information{
-				    	.o_wsale_product_sub{
-				    		margin-top: 15px;
-    						align-items: center;
+				// Smaller image on mobile list
+				.oe_product_image {
+					min-width: 120px;
+					width: 120px;
+					.oe_product_image_link {
+						min-height: 120px;
+						img { max-height: 120px; }
+					}
+				}
+				.oe_product_cart{
+					padding: 14px;
+					overflow: hidden;
+					.o_wsale_product_information{
+						padding-right: 0;
+						overflow: hidden;
+						.o_wsale_product_information_text{
+							display: flex;
+							flex-direction: column;
+							gap: 10px;
+							overflow: hidden;
+							.product_info, .product_variant{
+								width: 100%;
+								overflow: hidden;
+							}
+							.product_variant{
+								.js_add_cart_variants{
+									overflow: hidden;
+									.variant_attribute{
+										padding: 8px 0;
+										overflow: hidden;
+										.attribute_name{
+											font-size: 10px;
+										}
+										ul li label .form-check .radio_input_value{
+											font-size: 12px;
+										}
+									}
+								}
+							}
+						}
+						.o_wsale_product_sub{
+							flex-direction: column;
+							align-items: stretch !important;
+							gap: 8px;
+
+							.product_sub_detail{
+								width: 100%;
+								flex-wrap: wrap;
+								gap: 8px;
+								.product_price{
+									flex-direction: row;
+									align-items: baseline;
+									gap: 8px;
+								}
+							}
+
+							.o_wsale_product_btn{
+								width: 100%;
+								justify-content: stretch;
+								.a-submit{
+									flex: 1;
+									text-align: center;
+									padding: 14px;
+									font-size: 15px;
+									font-weight: 700;
+									border-radius: 10px;
+								}
+								.o_add_compare{
+									display: none;
+								}
+							}
 						}
 					}
 				}
 			}
 		}
 	}
-	@media (min-width: 992px) and (max-width: 1199.98px){
+
+	@media (min-width: 768px) and (max-width: 1199.98px){
 		.o_wsale_products_grid_table_wrapper{
 			.oe_product{
-			    .oe_product_cart{
-				    .o_wsale_product_information{
-				    	.o_wsale_product_sub{
-				    		margin-top: 15px;
-    						align-items: center;
+				.oe_product_cart{
+					.o_wsale_product_information{
+						.o_wsale_product_information_text{
+							.product_info{
+								width: 40%;
+							}
+							.product_variant{
+								width: 60%;
+							}
+						}
+						.o_wsale_product_sub{
+							margin-top: 12px;
 						}
 					}
 				}
@@ -551,8 +803,308 @@
 	    }
 	}
 }
-.availability_messages {
-	#out_of_stock_message {
-		display: none;
+// Hide Odoo native availability text on shop cards — we use our own .stock_badge
+.availability_messages,
+.availability_message_sell {
+	display: none !important;
+}
+
+/* Monthly payment badge — product cards (grid + list) */
+.monthly-payment-badge {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-top: 8px;
+	padding: 6px 10px;
+	background-color: #eef9f3;
+	border-radius: 8px;
+	font-size: 11px;
+	font-weight: 600;
+	color: #099D5D;
+	text-decoration: none;
+	transition: all 0.2s ease;
+	cursor: pointer;
+	.fa-credit-card {
+		font-size: 12px;
+		color: #099D5D;
+	}
+	&:hover {
+		background-color: #ddf3e8;
+		color: #077a48;
+	}
+}
+
+/* Product CTA link — grid view */
+#products_grid:not(.o_wsale_layout_list) {
+	.product-cta-link {
+		display: block;
+		text-align: center;
+		margin-top: 10px;
+		padding: 10px 16px;
+		background-image: linear-gradient(135deg, #099D5D, #7AC144);
+		color: #fff;
+		font-size: 13px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.3px;
+		border-radius: 10px;
+		text-decoration: none;
+		transition: all 0.2s ease;
+		&:hover {
+			transform: translateY(-1px);
+			box-shadow: 0 4px 12px rgba(9,157,93,0.3);
+			color: #fff;
+		}
+		.fa { font-size: 11px; }
+	}
+}
+
+/* Product CTA link — list view */
+#products_grid.o_wsale_layout_list {
+	.monthly-payment-badge {
+		margin-top: 0;
+		order: 3;
+	}
+	.product-cta-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 10px 20px;
+		background-image: linear-gradient(135deg, #099D5D, #7AC144);
+		color: #fff;
+		font-size: 13px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.3px;
+		border-radius: 10px;
+		text-decoration: none;
+		order: 4;
+		transition: all 0.2s ease;
+		white-space: nowrap;
+		&:hover {
+			transform: translateY(-1px);
+			box-shadow: 0 4px 12px rgba(9,157,93,0.3);
+			color: #fff;
+		}
+		.fa { font-size: 11px; }
+	}
+	@media (max-width: 767.98px){
+		.product-cta-link {
+			width: 100%;
+			justify-content: center;
+			text-align: center;
+		}
+	}
+}
+
+// Brand/category filter buttons — fix hover text going white
+#products_grid_before,
+.o_wsale_products_page {
+	.btn-light, .btn-fill-light {
+		background-color: #fff !important;
+		color: #212529 !important;
+		border: 1px solid #e8e9ea;
+		border-radius: 1rem !important;
+		transition: all 0.2s ease;
+		&:hover, &:focus, &:active, &.active {
+			background-color: #F5F6F7 !important;
+			color: #099D5D !important;
+			border-color: #099D5D !important;
+			box-shadow: none;
+		}
+		// Active/selected brand
+		&.active, &[aria-pressed="true"] {
+			background-color: #099D5D !important;
+			color: #fff !important;
+			border-color: #099D5D !important;
+		}
+		img {
+			max-height: 24px;
+			margin-right: 6px;
+		}
+	}
+}
+
+/* ==========================================
+   Compare Page (/shop/compare)
+   ========================================== */
+.oe_website_sale {
+	h3:has(+ .table-comparator) {
+		font-size: 22px;
+		font-weight: 800;
+		text-transform: uppercase;
+		font-style: italic;
+		color: #000;
+		margin-bottom: 24px;
+	}
+
+	.table-comparator {
+		border: none;
+		border-radius: 16px;
+		overflow: hidden;
+		background: #fff;
+		box-shadow: 0 2px 16px rgba(0,0,0,0.06);
+
+		td, th {
+			border-color: #f0f0f0;
+			vertical-align: middle;
+		}
+
+		thead {
+			tr {
+				td {
+					padding: 20px;
+					background: #fff;
+
+					&.o_ws_compare_image {
+						padding: 24px;
+						img {
+							border-radius: 12px;
+							max-height: 200px;
+							object-fit: contain;
+						}
+						.o_comparelist_remove {
+							background: #fff;
+							border-radius: 50%;
+							width: 30px;
+							height: 30px;
+							display: inline-flex;
+							align-items: center;
+							justify-content: center;
+							box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+							color: #999;
+							text-decoration: none;
+							transition: all 0.2s ease;
+							strong { font-size: 14px; }
+							&:hover {
+								background: #dc3545;
+								color: #fff;
+							}
+						}
+					}
+
+					&.td-top-left {
+						background: #F5F6F7;
+						border-radius: 16px 0 0 0;
+					}
+				}
+			}
+		}
+
+		.product_summary {
+			> * {
+				display: block;
+				margin: 12px 0;
+			}
+			.o_product_comparison_table {
+				font-weight: 700;
+				font-size: 15px;
+				color: #000;
+				text-decoration: none;
+				text-transform: uppercase;
+				font-style: italic;
+				line-height: 1.3;
+				&:hover { color: #099D5D; }
+			}
+			.o_comparison_price {
+				font-size: 14px;
+				strong { font-weight: 400; color: #888; }
+				del {
+					display: none !important;
+				}
+				span:not(del) {
+					font-weight: 900;
+					font-size: 20px;
+					color: #000;
+				}
+			}
+			.o_add_cart_form_compare {
+				.btn-primary {
+					background-image: linear-gradient(135deg, #099D5D, #7AC144);
+					border: none;
+					border-radius: 10px;
+					padding: 10px 24px;
+					font-weight: 700;
+					font-size: 13px;
+					text-transform: uppercase;
+					letter-spacing: 0.3px;
+					transition: all 0.2s ease;
+					&:hover {
+						transform: translateY(-1px);
+						box-shadow: 0 4px 12px rgba(9,157,93,0.3);
+					}
+				}
+			}
+		}
+
+		tbody {
+			tr {
+				&.clickable {
+					cursor: pointer;
+					th {
+						background-color: #F5F6F7;
+						font-size: 13px;
+						font-weight: 700;
+						text-transform: uppercase;
+						letter-spacing: 0.3px;
+						color: #000;
+						padding: 14px 20px;
+						.fa {
+							color: #099D5D;
+							margin-right: 8px;
+							transition: transform 0.2s ease;
+						}
+					}
+				}
+				td {
+					padding: 12px 20px;
+					font-size: 14px;
+					color: #333;
+				}
+			}
+		}
+
+		@media (max-width: 767.98px) {
+			font-size: 12px;
+			thead tr td {
+				padding: 12px;
+				&.o_ws_compare_image img {
+					max-height: 120px;
+				}
+			}
+			.product_summary {
+				.o_product_comparison_table { font-size: 12px; }
+				.o_comparison_price span:not(del) { font-size: 16px; }
+				.o_add_cart_form_compare .btn-primary {
+					padding: 8px 14px;
+					font-size: 11px;
+				}
+			}
+			tbody tr td { padding: 8px 12px; font-size: 12px; }
+		}
+	}
+}
+
+/* Compare panel (fixed bottom bar) */
+.o_product_feature_panel {
+	border-color: #099D5D !important;
+	border-radius: 16px 16px 0 0 !important;
+	box-shadow: 0 -4px 20px rgba(0,0,0,0.08);
+
+	.o_product_panel_header {
+		.o_product_circle {
+			background-color: #099D5D !important;
+		}
+	}
+	.o_comparelist_button {
+		.btn-primary {
+			background-image: linear-gradient(135deg, #099D5D, #7AC144);
+			border: none;
+			border-radius: 10px;
+			font-weight: 700;
+			&:hover {
+				box-shadow: 0 4px 12px rgba(9,157,93,0.3);
+			}
+		}
 	}
 }

--- a/website_freemoov/static/src/xml/stock_availability.xml
+++ b/website_freemoov/static/src/xml/stock_availability.xml
@@ -5,7 +5,7 @@
         <div id="stock_freemoov_message" t-if="!is_dropship and product_type == 'product' and !allow_out_of_stock_order and stock_availability lte 0 and !free_qty" t-attf-class="availability_message_#{product_template} my-2 d-flex align-items-center flex-column flex-md-row">
            
             <p class="label"><span class="o_ribbon bg-danger o_ribbon_left" t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"/>
-                <span>Out of stock</span>
+                <span>Rupture de stock</span>
             </p>
         
         <p class="label mb-1" t-if="product_id.is_available_trial">

--- a/website_freemoov/views/inherited_template.xml
+++ b/website_freemoov/views/inherited_template.xml
@@ -121,6 +121,24 @@
             </t>
         </xpath>
         <xpath expr="//div[hasclass('o_wsale_products_page')]" position="after">
+            <!-- Per-category editable zone below products (Odoo website editor) -->
+            <t t-if="category">
+                <div t-attf-class="oe_structure oe_empty" t-attf-id="oe_structure_category_bottom_#{category.id}"/>
+            </t>
+            <t t-if="not category">
+                <div class="oe_structure oe_empty" id="oe_structure_shop_bottom"/>
+            </t>
+            <t t-if="category and category.category_bottom_content">
+                <section class="category-bottom-content pt32 pb32 bg-white">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-12">
+                                <t t-out="category.category_bottom_content"/>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </t>
             <section class="faqs pt64 pb32">
                 <div class="container">
                     <div class="row justify-content-center">
@@ -168,18 +186,18 @@
         </xpath>
 
         <xpath expr="//div[hasclass('products_header')]" position="replace">
-            <div class="products_header btn-toolbar flex-nowrap align-items-baseline mb-3">
+            <div class="products_header btn-toolbar flex-nowrap align-items-center justify-content-between gap-3 mb-3">
                 <t t-if="is_view_active('website_sale.add_grid_or_list_option')" t-call="website_sale.add_grid_or_list_option">
-                    <t t-set="_classes" t-valuef="d-flex me-3"/>
+                    <t t-set="_classes" t-valuef="d-flex"/>
                 </t>
                 <button t-if="is_view_active('website_sale.sort') or opt_wsale_categories or opt_wsale_attributes or opt_wsale_attributes_top"
-                        t-attf-class="btn btn-{{navClass}} position-relative me-3 w-100 {{not opt_wsale_attributes_top and 'd-lg-none'}}"
+                        t-attf-class="btn btn-{{navClass}} position-relative {{not opt_wsale_attributes_top and 'd-lg-none'}}"
                         data-bs-toggle="offcanvas"
                         data-bs-target="#o_wsale_offcanvas">
-                    <i class="fa fa-sliders me-3"/><span class="fw-bold">Tous les filtres</span>
+                    <i class="fa fa-sliders me-2"/><span class="fw-bold">Tous les filtres</span>
                     <span t-if="isFilteringByPrice or attrib_set" t-attf-class="position-absolute top-0 start-100 translate-middle badge border border-{{navClass}} rounded-circle bg-danger p-1"><span class="visually-hidden">filters active</span></span>
                 </button>
-                <div class="d-flex">
+                <div class="d-flex align-items-center">
                     <t t-esc="len(products)"/><p class="ps-1 mb-0">produits trouvés</p>
                 </div>
             </div>
@@ -444,46 +462,49 @@
         <!-- <xpath expr="//span[contains(@t-attf-class, 'o_ribbon')]" position="replace">
         </xpath> -->
         <xpath expr="//form//div[hasclass('o_wsale_product_sub')]" position="replace">
-            <!-- <div class="prod_desc_div d-none">
-                <t t-esc="product.description" />
-            </div> -->
-            <div class="o_wsale_product_sub d-flex align-items-end pb-1">                
+            <div class="o_wsale_product_sub d-flex">
                 <t t-set="template_price_vals" t-value="get_product_prices(product)"/>
-                
-                <div class="o_wsale_product_btn"/>
-                
-                <div class="product_sub_detail align-items-center">
-                   <t t-set="stock_available" t-value="product.get_stock_availability(website)"></t>
-                   <t t-if="not stock_available['is_dropship']">
-                        <t t-if="stock_available['qty_avail'] &gt; 0">
-                                <p class="label"><span class="o_ribbon bg-primary o_ribbon_left" t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"/>
-                                    <span>En stock</span>
-                                </p>
-                        </t> 
-                        <t t-else="">
-                            <p class="label"><span class="o_ribbon bg-danger o_ribbon_left" t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"/>
-                                <span>Out of stock</span>
-                            </p>
-                        </t>
-                   </t>
+
+                <div class="product_sub_detail">
                     <div class="product_price" itemprop="offers" itemscope="itemscope" itemtype="http://schema.org/Offer">
-                        <t t-if="len(product.attribute_line_ids)>0">
-                            <span>à partir de</span>
-                        </t>
-                        <span class="h6 mb-0" t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale" t-esc="template_price_vals['price_reduce']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
-                        <span class="h6 mb-0" t-else="" t-field="website.prevent_zero_price_sale_text"/>
-                        <br/>
-                        
+                        <div class="price_wrapper">
+                            <t t-if="'base_price' in template_price_vals">
+                                <del class="price_original">
+                                    <span t-esc="template_price_vals['base_price']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}" />
+                                </del>
+                            </t>
+                            <span class="price_current" t-if="template_price_vals['price_reduce'] or not website.prevent_zero_price_sale">
+                                <span class="h6 mb-0" t-esc="template_price_vals['price_reduce']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
+                                <small class="text-muted" style="font-size: 10px;">TVAC</small>
+                            </span>
+                            <span class="h6 mb-0" t-if="not (template_price_vals['price_reduce'] or not website.prevent_zero_price_sale)" t-field="website.prevent_zero_price_sale_text"/>
+                        </div>
                         <span itemprop="price" style="display:none;" t-esc="template_price_vals['price_reduce']" />
                         <span itemprop="priceCurrency" style="display:none;" t-esc="website.currency_id.name" />
-                        <t t-if="'base_price' in template_price_vals">
-                            <del t-attf-class="text-muted me-1 h6 mb-0" style="white-space: nowrap;">
-                                <em class="small" t-esc="template_price_vals['base_price']" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}" />
-                            </del>
-                        </t>
                     </div>
+
+                    <t t-set="stock_available" t-value="product.get_stock_availability(website)"/>
+                    <t t-if="not stock_available['is_dropship']">
+                        <t t-if="stock_available['qty_avail'] &gt; 0">
+                            <span class="stock_badge stock_available"><span class="stock_dot"/>Disponible en ligne</span>
+                        </t>
+                        <t t-else="">
+                            <span class="stock_badge stock_unavailable"><span class="stock_dot"/>Rupture de stock</span>
+                        </t>
+                    </t>
                 </div>
+
+                <div class="o_wsale_product_btn"/>
             </div>
+            <!-- Monthly payment badge -->
+            <a t-att-href="product_href" class="monthly-payment-badge">
+                <i class="fa fa-credit-card"></i>
+                <span>Payez par mois</span>
+            </a>
+            <!-- Product CTA -->
+            <a t-att-href="product_href" class="product-cta-link">
+                Découvrir <i class="fa fa-arrow-right ms-1"></i>
+            </a>
         </xpath>
     </template>
     <template id="inherit_wishlist_button" inherit_id="website_sale_wishlist.add_to_wishlist" name="Inherit Wishlist Button">
@@ -501,19 +522,7 @@
          </a>
         </xpath>
     </template> -->
-    <template id="products_add_to_cart" inherit_id="website_sale.products_item" active="True" name="Add to Cart" >
-        <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
-            <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
-            <input name="product_id" t-att-value="product_variant_id" type="hidden"/>
-            <t t-if="product_variant_id and template_price_vals['price_reduce'] or not website.prevent_zero_price_sale">
-                <a t-if="product._website_show_quick_add()"
-                   href="#" role="button" class="btn btn-outline-primary a-submit" aria-label="Shopping cart" title="Shopping cart">
-                    <span class="icon-shopping-cart"/>
-                </a>
-            </t>
-        </xpath>
-    </template>
-    <template id="products_add_to_cart" inherit_id="website_sale.products_item" active="True" name="Add to Cart" >
+    <template id="products_add_to_cart" inherit_id="website_sale.products_item" active="True" name="Add to Cart">
         <xpath expr="//div[hasclass('o_wsale_product_btn')]" position="inside">
             <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
             <input name="product_id" t-att-value="product_variant_id" type="hidden"/>
@@ -539,16 +548,40 @@
 
     <template id="product_details_inherited" inherit_id="website_sale.product" name="Product Details">
         <xpath expr="//section[@id='product_detail']" position="after">
-            <section class="properties mt32 mb40 oe_structure oe_empty">
+            <section class="properties mt32 mb40">
                 <div class="container">
                     <div class="bg-color">
-                        <div class="row">
+                        <div class="row properties-layout">
+                            <!-- Stats icons: mobile FIRST (order-1), desktop RIGHT (order-md-2) -->
+                            <div class="col-lg-6 pt16 pb16 order-1 order-md-2">
+                                <div class="properties-stats-banner">
+                                    <t t-set="count" t-value="0"></t>
+                                    <div class="d-flex justify-content-around align-items-center mb24">
+                                        <div class="row">
+                                            <t t-foreach="product.attribute_line_ids" t-as="attribute" t-if="count &lt; 6">
+                                                <t t-set="count" t-value="count + 1"></t>
+                                                <div class="col-4 mb24">
+                                                    <div class="propertie-box text-center">
+                                                        <div t-if="attribute.attribute_id.image_1920 or editable"
+                                                        t-field="attribute.attribute_id.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_256'}" />
+                                                        <p class="name mb-0" t-esc="attribute.attribute_id.name"></p>
+                                                        <t t-if="attribute.attribute_default_val">
+                                                            <p class="fw-bold mb-0" t-esc="attribute.attribute_default_val.name"></p>
+                                                        </t>
+                                                    </div>
+                                                </div>
+                                            </t>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- Accordion: mobile SECOND (order-2), desktop LEFT (order-md-1) -->
                             <div class="col-lg-6 pt16 pb16 order-2 order-md-1">
-                                <div class="data">
-                                    <p class="" t-if="product.summary">
+                                <div class="properties-content-block">
+                                <div class="data" t-if="product.summary">
+                                    <p>
                                         <span t-esc="product.summary" style=""/>
                                     </p>
-                                    <!-- <p>La trottinette électrique Navee S65 est un vrai tapis volant ! Ces suspensions à torsion et ces pneus tubeless en 10 pouces lui procurent un confort irréprochable. Tous les défauts (ou presque) des routes urbaines sont absorbées vous garantissant un réel plaisir de conduire.</p> -->
                                 </div>
                                 <section class="s_faq_collapse o_colored_level" data-snippet="s_faq_collapse" data-name="Accordion" style="background-image: none;">
                                     <div class="container">
@@ -683,31 +716,8 @@
                                     </div>
                                 </section>
                             </div>
-                            <div class="col-lg-6 pt16 pb16 order-1 order-md-2">
-                                <div class="d-flex justify-content-around align-items-center mb24">
-                                    <t t-set="count" t-value="0"></t>
-                                    <div class="row">
-                                        <t t-foreach="product.attribute_line_ids" t-as="attribute" t-if="count &lt; 6">
-                                            <t t-set="count" t-value="count + 1"></t>
-                                            <div class="col-4 mb24">
-                                                <div class="propertie-box text-center">
-                                                    <div t-if="attribute.attribute_id.image_1920 or editable" 
-                                                    t-field="attribute.attribute_id.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_256'}" />
-                                                    <p class="name mb-0" t-esc="attribute.attribute_id.name"></p>
-                                                    <t t-if="attribute.attribute_default_val">
-                                                        <p class="fw-bold" t-if="attribute.attribute_default_val" t-esc="attribute.attribute_default_val.name"></p>
-                                                    </t>
-                                                    <!-- <t t-else="">
-                                                        <p class="fw-bold" t-if="attribute.value_ids" t-esc="attribute.value_ids[0].name"></p>
-                                                    </t> -->
-                                                    
-                                                </div>
-                                            </div>
-                                        </t>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                            </div><!-- /col-lg-6 accordion -->
+                        </div><!-- /row properties-layout -->
                     </div>
                 </div>
             </section>
@@ -1034,29 +1044,43 @@
         <xpath expr="//t[@t-placeholder='select']" position="after">
             <t t-call="website_sale.product_price"/>
             <t t-if="not product.is_dropship_product">
-                <t t-if="product.virtual_available &gt; 0">
+                <t t-set="p_avail" t-value="product.sudo().virtual_available"/>
+                <t t-if="p_avail &gt; 0">
                     <p class="label"><span class="o_ribbon bg-primary o_ribbon_left" />
-                        <span> En stock</span>
+                        <span> Disponible en ligne</span>
                     </p>
                 </t>
-                <t t-if="product.virtual_available &lt;= 0">
+                <t t-if="p_avail &lt;= 0">
                     <p class="label"><span class="o_ribbon bg-danger o_ribbon_left" t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"/>
-                        <span> Out of stock </span>
+                        <span> Rupture de stock </span>
                     </p>
                 </t>
             </t>
+            <!-- Badge "Payez en 3x ou 24x" below price -->
+            <div class="installment-badge-inline mt-1 mb-3">
+                <a href="/payez-par-mois" class="btn btn-sm btn-dark rounded-pill px-3 py-1" style="font-size: 10px;">
+                    Payez en 3x ou 24x
+                </a>
+            </div>
 
         </xpath>
         <xpath expr="//div[@id='product_option_block']" position="after">
-            <div class="compare-box text-center">
-                <p class="my-3"><span class="border-bottom border-dark">Voir la disponibilité en magasin</span></p>
+            <!-- Unified actions bar: wishlist + compare + store availability on one line -->
+            <div class="product-actions-bar">
+                <button t-if="product_variant" type="button" role="button" class="action-item o_add_wishlist_dyn" t-att-disabled='in_wish or None' t-att-data-product-template-id="product.id" t-att-data-product-product-id="product_variant.id" data-action="o_wishlist" title="Ajouter aux favoris">
+                    <i class="fa fa-heart-o"></i>
+                    <span>Favoris</span>
+                </button>
                 <t t-set="categories" t-value="product.valid_product_template_attribute_line_ids._prepare_categories_for_display()"/>
                 <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
-                <button t-if="product_variant_id and categories" type="button" role="button" class="d-md-inline-block btn o_add_compare p-0 order-2" title="Compare" aria-label="Compare" t-att-data-product-product-id="product_variant_id" data-action="o_comparelist">
-                    Comparez
-                    <i class="icon-circle-plus"></i>
-                    <!-- <img class="img img-fluid ms-2" src="/website_freemoov/static/src/img/plus-circle.png" alt="Hero Img"/> -->
+                <button t-if="product_variant_id and categories" type="button" role="button" class="action-item btn-compare" title="Comparer" aria-label="Comparer" t-att-data-product-product-id="product_variant_id" data-action="o_comparelist">
+                    <i class="fa fa-exchange"></i>
+                    <span>Comparer</span>
                 </button>
+                <a href="#" class="action-item store-availability">
+                    <i class="fa fa-map-marker"></i>
+                    <span>Disponibilité magasin</span>
+                </a>
             </div>
         </xpath>
         <!-- <xpath expr="//div[@id='o_wsale_cta_wrapper']" position="before">
@@ -1068,47 +1092,95 @@
             <attribute name="t-if">stock_available &gt; 0</attribute>
         </xpath> -->
         <xpath expr="//div[@id='add_to_cart_wrap']" position="before">
-            <ul class="text custom_product_list mb32">
-                <t t-set="is_dropship" t-value="product.dropship_product()" />
-                <li class="mb-1" t-if="not is_dropship">
-                    <p class="label mb-1"><span class="o_ribbon bg-primary o_ribbon_left" />
-                        <span> En stock</span>
-                    </p>
-                </li>
-                <li class="mb-1">
-                    <i class="icon-truck"></i>
-                    <!-- <img class="img img-fluid me-2" src="/website_freemoov/static/src/img/truck.png" alt="Hero Img"/> -->
-                    <span>Délai de 1 à 5 jours ouvrés</span>
-                </li>
-                <li class="mb-0">
-                    <i class="icon-check"></i>
-                    <!-- <img class="img img-fluid me-2" src="/website_freemoov/static/src/img/right.png" alt="Hero Img"/> -->
+            <div class="trust-features">
+                <div class="trust-feature-item">
+                    <i class="fa fa-truck"></i>
+                    <span>Livraison en 1 à 5 jours ouvrés</span>
+                </div>
+                <div class="trust-feature-item">
+                    <i class="fa fa-refresh"></i>
+                    <span>Retour gratuit sous 30 jours</span>
+                </div>
+                <div class="trust-feature-item">
+                    <i class="fa fa-shield"></i>
+                    <span>Garantie 2 ans incluse</span>
+                </div>
+                <div class="trust-feature-item">
+                    <i class="fa fa-wrench"></i>
                     <span>Services premium Freemoov compris</span>
-                </li>
-            </ul>
+                </div>
+            </div>
         </xpath>
         <xpath expr="//div[@id='o_product_terms_and_share']" position="after">
-            <div class="custom-text">
-                <div class="payment-method text-center text-md-start">
-                    <p>Moyen de paiement sécurisé</p>
-                    <img src="/website_freemoov/static/src/img/payment_icons.png" class="img img-fluid"/>
+            <div class="custom-text"><div data-oe-expression="//player.vimeo.com/video/1074934588?autoplay=1&amp;muted=1&amp;autopause=0&amp;controls=0&amp;loop=1" class="media_iframe_video">
+                <div class="css_editable_mode_display"/>
+                <div class="media_iframe_video_size"/>
+                <iframe src="//player.vimeo.com/video/1074934588?autoplay=1&amp;muted=1&amp;autopause=0&amp;controls=0&amp;loop=1" frameborder="0" allowfullscreen="allowfullscreen"/>
+            </div></div>
+            <div class="trust-block">
+                <!-- Payer en plusieurs fois -->
+                <div class="installment-block">
+                    <i class="fa fa-credit-card"></i>
+                    <p class="mb-0">
+                        <span class="text-600">Payez par mois : à partir de </span>
+                        <a href="/payez-par-mois" class="installment-link"><strong>125,62€ / mois en 30 fois</strong></a>
+                    </p>
+                    <p class="installment-note mb-0">TAEG de 5,99%. Uniquement disponible en magasin.</p>
                 </div>
-                <div class="advantages">
-                    <h5 class="text-uppercase fw-bold mb-3">Vos avantages Freemoov</h5>
-                    <ul class="text">
-                        <li class="mb-2">
-                            <img class="img img-fluid me-2" src="/website_freemoov/static/src/img/right.png" alt="Hero Img"/>
-                            <span>Expert en réparation de trottinette électrique</span>
-                        </li>
-                        <li class="mb-2">
-                            <img class="img img-fluid me-2" src="/website_freemoov/static/src/img/right.png" alt="Hero Img"/>
-                            <span>Visite show-room et essai avant achat</span>
-                        </li>
-                        <li class="mb-2">
-                            <img class="img img-fluid me-2" src="/website_freemoov/static/src/img/right.png" alt="Hero Img"/>
-                            <span>Magasin physique à votre écoute</span>
-                        </li>
-                    </ul>
+
+                <!-- Paiement sécurisé -->
+                <div class="payment-secure-block">
+                    <h6 class="trust-title"><i class="fa fa-lock"></i> Paiement en ligne sécurisé</h6>
+                    <p class="mb-2">Payez de manière 100% sécurisée avec le moyen de paiement qui vous convient.</p>
+                    <img src="/website_freemoov/static/src/img/payment_icons.png" class="img img-fluid payment-logos"/>
+                </div>
+
+                <!-- Achetez en toute confiance -->
+                <div class="confidence-block">
+                    <h6 class="trust-title">ACHETEZ EN TOUTE CONFIANCE</h6>
+                    <div class="confidence-badges">
+                        <a href="/about-us" class="trust-badge-link">
+                            <i class="fa fa-check"></i>
+                            <span>Spécialiste en mobilité</span>
+                        </a>
+                        <a href="/services-atelier" class="trust-badge-link">
+                            <i class="fa fa-check"></i>
+                            <span>Services après-vente ultra rapide</span>
+                        </a>
+                        <a href="/magasin" class="trust-badge-link">
+                            <i class="fa fa-check"></i>
+                            <span>Magasin et Atelier accessible</span>
+                        </a>
+                    </div>
+                </div>
+
+                <!-- Besoin de conseils -->
+                <div class="contact-block">
+                    <h6 class="trust-title"><i class="fa fa-phone"></i> Besoin de conseils ?</h6>
+                    <p class="mb-1">Nos experts sont à votre disposition pour vous aider à trouver le produit qui vous correspond.</p>
+                    <a href="tel:+3281659166" class="phone-number">+32 81 65 91 66</a>
+                </div>
+
+                <!-- Avis clients -->
+                <div class="reviews-block">
+                    <div class="reviews-score">
+                        <span class="score">4.8</span>
+                        <span class="stars">
+                            <i class="fa fa-star"></i>
+                            <i class="fa fa-star"></i>
+                            <i class="fa fa-star"></i>
+                            <i class="fa fa-star"></i>
+                            <i class="fa fa-star-half-o"></i>
+                        </span>
+                        <span class="reviews-label">Avis clients</span>
+                    </div>
+                    <a href="https://www.google.com/maps/place/Freemoov" target="_blank" rel="noopener noreferrer" class="reviews-link">Voir les avis Google <i class="fa fa-external-link"></i></a>
+                </div>
+
+                <!-- Qui sommes-nous -->
+                <div class="about-block">
+                    <h6 class="trust-title">Vos avantages Freemoov</h6>
+                    <p class="mb-0">Chez <strong>Freemoov</strong>, la mobilité est notre passion. Spécialisés dans les trottinettes électriques, fatbikes et gyroroues, nous vous accompagnons dans le choix et l'entretien de votre véhicule. Retrouvez-nous dans nos magasins de <strong>Liège</strong> et <strong>Namur</strong>.</p>
                 </div>
             </div>
         </xpath>

--- a/website_freemoov/views/inherited_template.xml
+++ b/website_freemoov/views/inherited_template.xml
@@ -551,173 +551,148 @@
             <section class="properties mt32 mb40">
                 <div class="container">
                     <div class="bg-color">
-                        <div class="row properties-layout">
-                            <!-- Stats icons: mobile FIRST (order-1), desktop RIGHT (order-md-2) -->
-                            <div class="col-lg-6 pt16 pb16 order-1 order-md-2">
-                                <div class="properties-stats-banner">
-                                    <t t-set="count" t-value="0"></t>
-                                    <div class="d-flex justify-content-around align-items-center mb24">
-                                        <div class="row">
-                                            <t t-foreach="product.attribute_line_ids" t-as="attribute" t-if="count &lt; 6">
-                                                <t t-set="count" t-value="count + 1"></t>
-                                                <div class="col-4 mb24">
-                                                    <div class="propertie-box text-center">
-                                                        <div t-if="attribute.attribute_id.image_1920 or editable"
-                                                        t-field="attribute.attribute_id.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_256'}" />
-                                                        <p class="name mb-0" t-esc="attribute.attribute_id.name"></p>
-                                                        <t t-if="attribute.attribute_default_val">
-                                                            <p class="fw-bold mb-0" t-esc="attribute.attribute_default_val.name"></p>
-                                                        </t>
+                        <!-- Stats badges: full-width banner at top -->
+                        <div class="properties-stats-banner">
+                            <t t-set="count" t-value="0"></t>
+                            <div class="stats-grid">
+                                <t t-foreach="product.attribute_line_ids" t-as="attribute" t-if="count &lt; 6">
+                                    <t t-set="count" t-value="count + 1"></t>
+                                    <div class="propertie-box text-center">
+                                        <div t-if="attribute.attribute_id.image_1920 or editable"
+                                        t-field="attribute.attribute_id.image_1920" t-options="{'widget': 'image', 'preview_image': 'image_256'}" />
+                                        <p class="name mb-0" t-esc="attribute.attribute_id.name"></p>
+                                        <t t-if="attribute.attribute_default_val">
+                                            <p class="fw-bold mb-0" t-esc="attribute.attribute_default_val.name"></p>
+                                        </t>
+                                    </div>
+                                </t>
+                            </div>
+                        </div>
+                        <!-- Content: full-width below stats -->
+                        <div class="properties-content-block">
+                            <div class="data" t-if="product.summary">
+                                <span t-esc="product.summary" style=""/>
+                            </div>
+                            <section class="s_faq_collapse o_colored_level" data-snippet="s_faq_collapse" data-name="Accordion" style="background-image: none;">
+                                <div class="container">
+                                    <div id="myCollapse" class="accordion accordion-grid" role="tablist">
+                                        <div class="card bg-white" data-name="Item" t-if="product.pro_description">
+                                            <a href="#" role="tab" data-bs-toggle="modal" aria-expanded="false" class="card-header py-3 collapsed s_faq_collapse_right_icon" data-bs-target="#descriptionmodel">Description</a>
+                                        </div>
+                                        <div t-if="product.pro_description" class="modal modal-fullscreen fade" id="descriptionmodel" tabindex="-1" aria-labelledby="descriptionmodelLabel" aria-hidden="true">
+                                            <div class="modal-dialog">
+                                                <div class="modal-content">
+                                                    <div class="modal-header border-bottom-0 mx-auto">
+                                                        <h3 class="modal-title text-uppercase fw-bold" id="descriptionmodelLabel">Description &amp; images</h3>
+                                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                                    </div>
+                                                    <div class="modal-body">
+                                                        <div class="row">
+                                                            <div class="col-lg-12">
+                                                                <p class="card-text pro-desc o_default_snippet_text"><t t-esc="product.pro_description"/></p>
+                                                            </div>
+                                                        </div>
                                                     </div>
                                                 </div>
-                                            </t>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- Accordion: mobile SECOND (order-2), desktop LEFT (order-md-1) -->
-                            <div class="col-lg-6 pt16 pb16 order-2 order-md-1">
-                                <div class="properties-content-block">
-                                <div class="data" t-if="product.summary">
-                                    <p>
-                                        <span t-esc="product.summary" style=""/>
-                                    </p>
-                                </div>
-                                <section class="s_faq_collapse o_colored_level" data-snippet="s_faq_collapse" data-name="Accordion" style="background-image: none;">
-                                    <div class="container">
-                                        <div id="myCollapse" class="accordion" role="tablist">
-                                            <div class="card bg-white" data-name="Item" t-if="product.pro_description">
-                                                <a href="#" role="tab" data-bs-toggle="modal" aria-expanded="false" class="card-header py-3 collapsed s_faq_collapse_right_icon" data-bs-target="#descriptionmodel">Description</a>
                                             </div>
-                                            <div t-if="product.pro_description" class="modal modal-fullscreen fade" id="descriptionmodel" tabindex="-1" aria-labelledby="descriptionmodelLabel" aria-hidden="true">
+                                        </div>
+                                        <t t-set="category_ids" t-value="product.attribute_line_ids.attribute_id.mapped('category_id')"/>
+                                        <t t-if="product.attribute_line_ids and len(product.attribute_line_ids) &gt; 5">
+                                            <div class="card bg-white" data-name="Item">
+                                                <a type="button" data-bs-toggle="modal" data-bs-target="#exampleModal" aria-expanded="false" class="py-3 btn collapsed card-header s_faq_collapse_right_icon text-start">Caractéristiques techniques</a>
+                                            </div>
+                                            <div class="modal modal-fullscreen fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
                                                 <div class="modal-dialog">
                                                     <div class="modal-content">
                                                         <div class="modal-header border-bottom-0 mx-auto">
-                                                            <h3 class="modal-title text-uppercase fw-bold" id="descriptionmodelLabel">Description &amp; images</h3>
+                                                            <h3 class="modal-title text-uppercase fw-bold" id="exampleModalLabel">Caractéristiques techniques</h3>
                                                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                                         </div>
                                                         <div class="modal-body">
-                                                            <div class="row">
-                                                                <div class="col-lg-12">
-                                                                    <p class="card-text pro-desc o_default_snippet_text"><t t-esc="product.pro_description"/></p>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <t t-set="category_ids" t-value="product.attribute_line_ids.attribute_id.mapped('category_id')"/>
-                                            
-                                            <t t-if="product.attribute_line_ids and len(product.attribute_line_ids) &gt; 5">
-                                                <div class="card bg-white" data-name="Item">
-                                                    <a type="button" data-bs-toggle="modal" data-bs-target="#exampleModal" aria-expanded="false" class="py-3 btn collapsed card-header s_faq_collapse_right_icon text-start">Caractéristiques techniques</a>
-                                                </div>
-                                                <div class="modal modal-fullscreen fade" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
-                                                    <div class="modal-dialog">
-                                                        <div class="modal-content">
-                                                            <div class="modal-header border-bottom-0 mx-auto">
-                                                                <h3 class="modal-title text-uppercase fw-bold" id="exampleModalLabel">Technical characteristics</h3>
-                                                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                                            </div>
-                                                            <div class="modal-body">
-                                                                <div class="row justify-content-between">
-                                                                    <t t-set="category_ids" t-value="product.attribute_line_ids.attribute_id.mapped('category_id')"/>
-                                                                    <t t-foreach="category_ids" t-as="category_id">
-                                                                        <div class="col-md-5 pt16 pb16 col-12 px-3 me-lg-3 column">
-                                                                            <table>
-                                                                                <div class="row">
-                                                                                    <h6 class="title fw-bold px-0" t-esc="category_id.name">Batterie</h6>
-                                                                                </div>
-                                                                            </table>
-                                                                            <t t-set="attributes" t-value="product.attribute_line_ids.filtered(lambda r: r.attribute_id.category_id == category_id)"/>
-                                                                                    <t t-foreach="attributes" t-as="bettery_line">
-                                                                                    <div class="row">
-                                                                                        <p class="col px-0 mb-0 py-2"><t t-esc="bettery_line.attribute_id.name or ''"/></p>
-                                                                                       
-                                                                                        <t t-foreach="bettery_line.value_ids" t-as="value">
-                                                                                            <p class="col px-0 mb-0 py-2 text-end"><t t-esc="value.name or ''"/></p>
-                                                                                        </t>
-                                                                                        
-                                                                                    </div>
-                                                                                </t>
-                                                                        </div>
-                                                                    </t>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </t>
-                                            <t t-if="product.attribute_line_ids and len(product.attribute_line_ids) &lt; 5">
-                                                <div class="card bg-white" data-name="Item">
-                                                    <a href="#" role="tab" data-bs-toggle="collapse" aria-expanded="false" class="collapsed card-header py-3 s_faq_collapse_right_icon o_default_snippet_text" data-bs-target="#myCollapseTab44542_2">Caractéristiques techniques</a>
-                                                    <div class="collapse" data-bs-parent="#myCollapse" role="tabpanel" id="myCollapseTab44542_2">
-                                                        <div class="card-body specification-box">
-                                                            <!-- <p>La trottinette électrique Navee S65 est un vrai tapis volant ! Ces suspensions à torsion et ces pneus tubeless en 10 pouces lui procurent un confort irréprochable. Tous les défauts (ou presque) des routes urbaines sont absorbées vous garantissant un réel plaisir de conduire.</p> -->
-                                                            
-                                                            <t t-if="product.attribute_line_ids">
+                                                            <div class="row justify-content-between">
                                                                 <t t-set="category_ids" t-value="product.attribute_line_ids.attribute_id.mapped('category_id')"/>
                                                                 <t t-foreach="category_ids" t-as="category_id">
-                                                                <div class="col-md-12 pt16 pb16 col-12 px-3 me-lg-3 column">
-                                                                    <table>
-                                                                        <div class="row">
-                                                                            <h6 class="title fw-bold px-0" t-esc="category_id.name">Batterie</h6>
-                                                                        </div>
+                                                                    <div class="col-md-5 pt16 pb16 col-12 px-3 me-lg-3 column">
+                                                                        <h6 class="title fw-bold px-0" t-esc="category_id.name">Batterie</h6>
                                                                         <t t-set="attributes" t-value="product.attribute_line_ids.filtered(lambda r: r.attribute_id.category_id == category_id)"/>
                                                                         <t t-foreach="attributes" t-as="bettery_line">
-                                                                            <div class="row attribute-row">
+                                                                            <div class="row">
                                                                                 <p class="col px-0 mb-0 py-2"><t t-esc="bettery_line.attribute_id.name or ''"/></p>
                                                                                 <t t-foreach="bettery_line.value_ids" t-as="value">
-                                                                                    <p class="col-2 px-0 mb-0 py-2 text-center"><t t-esc="value.name or ''"/></p>
+                                                                                    <p class="col px-0 mb-0 py-2 text-end"><t t-esc="value.name or ''"/></p>
                                                                                 </t>
                                                                             </div>
                                                                         </t>
-                                                                    </table>
-                                                                </div>
+                                                                    </div>
                                                                 </t>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </t>
+                                        <t t-if="product.attribute_line_ids and len(product.attribute_line_ids) &lt; 5">
+                                            <div class="card bg-white" data-name="Item">
+                                                <a href="#" role="tab" data-bs-toggle="collapse" aria-expanded="false" class="collapsed card-header py-3 s_faq_collapse_right_icon o_default_snippet_text" data-bs-target="#myCollapseTab44542_2">Caractéristiques techniques</a>
+                                                <div class="collapse" data-bs-parent="#myCollapse" role="tabpanel" id="myCollapseTab44542_2">
+                                                    <div class="card-body specification-box">
+                                                        <t t-if="product.attribute_line_ids">
+                                                            <t t-set="category_ids" t-value="product.attribute_line_ids.attribute_id.mapped('category_id')"/>
+                                                            <t t-foreach="category_ids" t-as="category_id">
+                                                                <div class="col-md-12 pt16 pb16 col-12 px-3 me-lg-3 column">
+                                                                    <h6 class="title fw-bold px-0" t-esc="category_id.name">Batterie</h6>
+                                                                    <t t-set="attributes" t-value="product.attribute_line_ids.filtered(lambda r: r.attribute_id.category_id == category_id)"/>
+                                                                    <t t-foreach="attributes" t-as="bettery_line">
+                                                                        <div class="row attribute-row">
+                                                                            <p class="col px-0 mb-0 py-2"><t t-esc="bettery_line.attribute_id.name or ''"/></p>
+                                                                            <t t-foreach="bettery_line.value_ids" t-as="value">
+                                                                                <p class="col-2 px-0 mb-0 py-2 text-center"><t t-esc="value.name or ''"/></p>
+                                                                            </t>
+                                                                        </div>
+                                                                    </t>
+                                                                </div>
                                                             </t>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </t>
-                                            <div class="card bg-white" data-name="Item" t-if="product.delivery_return">
-                                                <a href="#" role="tab" data-bs-toggle="modal" aria-expanded="false" class="collapsed card-header py-3 o_default_snippet_text s_faq_collapse_right_icon" data-bs-target="#livraisonmodel">Livraison &amp; retour</a>
-                                            </div>
-                                            <div t-if="product.delivery_return" class="modal modal-fullscreen fade" id="livraisonmodel" tabindex="-1" aria-labelledby="livraisonmodelLabel" aria-hidden="true">
-                                                <div class="modal-dialog">
-                                                    <div class="modal-content">
-                                                        <div class="modal-header border-bottom-0 mx-auto">
-                                                            <h3 class="modal-title text-uppercase fw-bold" id="livraisonmodelLabel">Livraison &amp; retour</h3>
-                                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                                        </div>
-                                                        <div class="modal-body">
-                                                            <p class="card-text o_default_snippet_text pro-desc"><t t-esc="product.delivery_return or ''"/></p>
-                                                        </div>
+                                                        </t>
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="card bg-white" data-name="Item" t-if="product.warranty_support">
-                                                <a href="#" role="tab" data-bs-toggle="modal" aria-expanded="false" class="collapsed card-header py-3 o_default_snippet_text s_faq_collapse_right_icon" data-bs-target="#garantiemodel">Garantie &amp; Assistance</a>
+                                        </t>
+                                        <div class="card bg-white" data-name="Item" t-if="product.delivery_return">
+                                            <a href="#" role="tab" data-bs-toggle="modal" aria-expanded="false" class="collapsed card-header py-3 o_default_snippet_text s_faq_collapse_right_icon" data-bs-target="#livraisonmodel">Livraison &amp; retour</a>
+                                        </div>
+                                        <div t-if="product.delivery_return" class="modal modal-fullscreen fade" id="livraisonmodel" tabindex="-1" aria-labelledby="livraisonmodelLabel" aria-hidden="true">
+                                            <div class="modal-dialog">
+                                                <div class="modal-content">
+                                                    <div class="modal-header border-bottom-0 mx-auto">
+                                                        <h3 class="modal-title text-uppercase fw-bold" id="livraisonmodelLabel">Livraison &amp; retour</h3>
+                                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                                    </div>
+                                                    <div class="modal-body">
+                                                        <p class="card-text o_default_snippet_text pro-desc"><t t-esc="product.delivery_return or ''"/></p>
+                                                    </div>
+                                                </div>
                                             </div>
-                                            <div t-if="product.warranty_support" class="modal modal-fullscreen fade" id="garantiemodel" tabindex="-1" aria-labelledby="garantiemodelLabel" aria-hidden="true">
-                                                <div class="modal-dialog">
-                                                    <div class="modal-content">
-                                                        <div class="modal-header border-bottom-0 mx-auto">
-                                                            <h3 class="modal-title text-uppercase fw-bold" id="garantiemodelLabel">Garantie &amp; Assistance</h3>
-                                                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                                        </div>
-                                                        <div class="modal-body">
-                                                            <p class="card-text o_default_snippet_text pro-desc"><t t-esc="product.warranty_support or ''"/></p>
-                                                        </div>
+                                        </div>
+                                        <div class="card bg-white" data-name="Item" t-if="product.warranty_support">
+                                            <a href="#" role="tab" data-bs-toggle="modal" aria-expanded="false" class="collapsed card-header py-3 o_default_snippet_text s_faq_collapse_right_icon" data-bs-target="#garantiemodel">Garantie &amp; Assistance</a>
+                                        </div>
+                                        <div t-if="product.warranty_support" class="modal modal-fullscreen fade" id="garantiemodel" tabindex="-1" aria-labelledby="garantiemodelLabel" aria-hidden="true">
+                                            <div class="modal-dialog">
+                                                <div class="modal-content">
+                                                    <div class="modal-header border-bottom-0 mx-auto">
+                                                        <h3 class="modal-title text-uppercase fw-bold" id="garantiemodelLabel">Garantie &amp; Assistance</h3>
+                                                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                                    </div>
+                                                    <div class="modal-body">
+                                                        <p class="card-text o_default_snippet_text pro-desc"><t t-esc="product.warranty_support or ''"/></p>
                                                     </div>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
-                                </section>
-                            </div>
-                            </div><!-- /col-lg-6 accordion -->
-                        </div><!-- /row properties-layout -->
+                                </div>
+                            </section>
+                        </div>
                     </div>
                 </div>
             </section>
@@ -823,34 +798,34 @@
             <section class="safety pt64 pb64 oe_structure oe_empty">
                 <div class="container">
                     <div class="row">
-                        <div class="col-lg-6 pt16 pb16">
+                        <div class="col-lg-6 pb16 pt32">
                             <div class="information h-100">
                                 <div class="row">
                                     <div class="col-6 detail">
-                                        <h5 class="fw-bold text-uppercase text-white">Pensez à votre sécurité</h5>
-                                        <a class="icon"><img class="img" src="/website_freemoov/static/src/img/arrow-left.png" alt="photo"/></a>
+                                        <h5 class="fw-bold text-uppercase text-white"><span style="font-weight: normal;">guide d'achat</span> <em>trottinette</em></h5>
+                                        <a class="icon" href="/blog/trottinette-electrique-1/guide-complet-pour-choisir-une-trottinette-electrique-1"><img class="img" src="/website_freemoov/static/src/img/arrow-left.png" alt="photo"/></a>
                                     </div>
                                     <div class="col-6">
-                                        <img class="img img-fluid photo" src="/website_freemoov/static/src/img/img1.png" alt="photo"/>
+                                        <img src="/web/image/18457-d67da69b/2.png" alt="Guide trottinette" class="img img-fluid photo" loading="lazy"/>
                                     </div>
                                 </div>
                             </div>
                         </div>
-                        <div class="col-lg-6 pt16 pb16">
+                        <div class="col-lg-6 pb16 pt24">
                             <div class="information h-100 two">
                                 <div class="row">
                                     <div class="col-6 detail">
-                                        <h5 class="fw-bold text-uppercase text-white">Découvrez nos accessoires</h5>
-                                        <a class="icon"><img class="img" src="/website_freemoov/static/src/img/arrow-left.png" alt="photo"/></a>
+                                        <h5 class="fw-bold text-uppercase text-white"><span style="font-weight: normal;">guide d'achat</span> <em>gyroroue</em></h5>
+                                        <a class="icon" href="/blog/gyroroue-2/le-guide-ultime-pour-choisir-une-gyroroue-2"><img class="img" src="/website_freemoov/static/src/img/arrow-left.png" alt="photo"/></a>
                                     </div>
                                     <div class="col-6">
-                                        <img class="img img-fluid photo" src="/website_freemoov/static/src/img/img2.png" alt="photo"/>
+                                        <img src="/web/image/18458-7e28d1ca/1.png" alt="Guide gyroroue" class="img img-fluid photo" loading="lazy"/>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-                </div>      
+                </div>
             </section>
             <div class="oe_structure oe_empty"></div>
 


### PR DESCRIPTION
## Summary

Port visual styling improvements from v17 staging to v16 production, plus additional shop/product UX rework.

### SCSS

**shop.scss**
- Product grid cards, list view specs table, stock badges, monthly payment badge, "Découvrir" CTA
- Brand filter hover, compare page, pagination
- Variant specs now visible in grid view as compact 2x2 badge grid
- Wishlist heart moved to card top-right overlay (absolute, rounded)
- Price display: 18px/800 weight in grid, 24px/900 in list, TVAC suffix styled
- "Prix :" pseudo-label above price in list view
- Compare button restyled as bordered pill with green hover
- Card hover shadow on grid, min-height 480px

**product_detail.scss**
- Sticky product images with dom.scrollFixedOffset() and CSS fallback top: 120px
- Custom carousel arrows, centered dot indicators
- Trust-features/trust-block, product-actions-bar, cart page styling
- Properties section: full-width stats-grid (6-col CSS grid) above accordion-grid (2-col)
- Responsive: 3-col tablet, 2-col mobile for stats; single-col accordion on mobile

**header.scss**
- Header always-visible fix (cancel Odoo hide-on-scroll-down)

### JS
- Carousel sticky override via `dom.scrollFixedOffset()` (replaces manual header detection)
- Share button, Owl carousel `.length` guards

### XML Templates
- Shop cards: stock badge, price wrapper with TVAC, variant specs display
- Product detail: trust-features, actions bar, trust-block, Vimeo embed
- Properties section: redesigned from 2-column to full-width stats banner + accordion grid
- "Pensez à votre sécurité" / "Découvrez nos accessoires" banners replaced with "Guide d'achat trottinette" / "Guide d'achat gyroroue" (links to blog posts)
- Per-category editable zone below shop products
- Stock text: French ("Disponible en ligne" / "Rupture de stock")

### Model
- Add `category_bottom_content` Html field on `product.public.category`

### Version
`16.0.0.0.7` → `16.0.0.1.0`

## Rollback plan
```bash
git checkout v16-pre-port-backup -- website_freemoov/
git commit -m "revert: rollback v16 styling port"
git push origin production
```

## Test plan
- [ ] Shop grid view: cards with stock badges, specs badges, heart overlay, prices
- [ ] Shop list view: specs table, "Prix :" label, TVAC, compare button
- [ ] Product detail: sticky image on scroll (no header overlap)
- [ ] Product detail: properties stats banner (6-col grid), accordion (2-col)
- [ ] Product detail: guide d'achat banners with blog links
- [ ] Cart page: green gradient buttons
- [ ] Mobile responsive on all pages
- [ ] No JS console errors
- [ ] Compare page styling