### PR TITLE
fix(perf): reduce CLS and improve homepage loading

### DIFF
--- a/website_freemoov/__manifest__.py
+++ b/website_freemoov/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'Website Freemoov',
     'category': 'Website',
-    'version': '16.0.0.1.4',
+    'version': '16.0.0.1.5',
     'summary': 'Website Freemoov',
     'author': '',
     'website' : '',

--- a/website_freemoov/migrations/16.0.0.1.5/post-migrate.py
+++ b/website_freemoov/migrations/16.0.0.1.5/post-migrate.py
@@ -1,0 +1,11 @@
+import logging
+from odoo import api, SUPERUSER_ID
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Clear asset bundles to force reload of updated CSS (feather font-display, homepage styles)."""
+    _logger.info("Clearing asset bundles for v16.0.0.1.5...")
+    cr.execute("DELETE FROM ir_attachment WHERE url LIKE '/web/assets/%';")
+    _logger.info("Asset bundles cleared.")

--- a/website_freemoov/static/src/scss/common.scss
+++ b/website_freemoov/static/src/scss/common.scss
@@ -38,6 +38,7 @@ a.btn {
 #ust_all_in_one_configure{
     background-color: #F5F6F7;
     padding-bottom: 0px !important;
+    min-height: 480px;
     .all-slider-header-title{
         span{
             h5{

--- a/website_freemoov/static/src/scss/feather.css
+++ b/website_freemoov/static/src/scss/feather.css
@@ -2,6 +2,7 @@
  
 @font-face {
   font-family: "feather";
+  font-display: swap;
   src: url('../fonts/feather.eot?t=1525787366991'); /* IE9*/
   src: url('../fonts/feather.eot?t=1525787366991#iefix') format('embedded-opentype'), /* IE6-IE8 */
   url('../fonts/feather.woff?t=1525787366991') format('woff'), /* chrome, firefox */
@@ -11,6 +12,7 @@
 
 @font-face {
   font-family: "feather";
+  font-display: swap;
   src:url("/website_freemoov/static/src/fonts/feather-webfont.eot");
   src:url("/website_freemoov/static/src/fonts/feather-webfont.eot?#iefix") format("embedded-opentype"),
     url("/website_freemoov/static/src/fonts/feather-webfont.woff") format("woff"),

--- a/website_freemoov/static/src/scss/homepage.scss
+++ b/website_freemoov/static/src/scss/homepage.scss
@@ -41,6 +41,7 @@
 			overflow: visible;
 			.carousel-item {
 				border-radius: 16px;
+				min-height: 330px;
 			}
 		}
 		.carousel-indicators {

--- a/website_freemoov/views/homepage_template.xml
+++ b/website_freemoov/views/homepage_template.xml
@@ -39,7 +39,8 @@
 											<div class="hero-img">
 												<img class="img img-fluid"
 													src="/website_freemoov/static/src/img/homepage/hero_img.png"
-													alt="Hero Img" />
+													alt="Hero Img"
+													width="389" height="389" />
 											</div>
 											<div class="row_content d-flex align-items-center">
 												<div class="row content w-100">
@@ -90,7 +91,8 @@
 											<div class="hero-img">
 												<img class="img img-fluid"
 													src="/website_freemoov/static/src/img/homepage/hero_img.png"
-													alt="Hero Img" />
+													alt="Hero Img"
+													width="389" height="389" />
 											</div>
 											<div class="row_content d-flex align-items-center">
 												<div class="row content w-100">
@@ -212,7 +214,8 @@
 											<div class="img">
 												<img class="img-fluid img"
 													src="/website_freemoov/static/src/img/homepage/clients1.png"
-													alt="client" />
+													alt="client"
+													width="62" height="55" loading="lazy" />
 											</div>
 											<div class="details w-75">
 												<h6 class="fw-bold">Réparation de pneus</h6>
@@ -228,7 +231,8 @@
 											<div class="img">
 												<img class="img-fluid img"
 													src="/website_freemoov/static/src/img/homepage/clients2.png"
-													alt="client" />
+													alt="client"
+													width="62" height="55" loading="lazy" />
 											</div>
 											<div class="details w-75">
 												<h6 class="fw-bold">Réglage de freins</h6>
@@ -244,7 +248,8 @@
 											<div class="img">
 												<img class="img-fluid img"
 													src="/website_freemoov/static/src/img/homepage/clients3.png"
-													alt="client" />
+													alt="client"
+													width="60" height="55" loading="lazy" />
 											</div>
 											<div class="details w-75">
 												<h6 class="fw-bold">Test drive</h6>
@@ -272,7 +277,8 @@
 									<div class="col-lg-7 pt8 pb8">
 										<img class="img-fluid"
 											src="/website_freemoov/static/src/img/homepage/Map.png"
-											alt="photo" />
+											alt="photo"
+											width="843" height="418" loading="lazy" />
 									</div>
 									<div class="col-lg-4 pt8 pb8 ms-xl-4">
 										<div class="title">
@@ -355,7 +361,9 @@
 											</div>
 											<div class="expert_img">
 												<img class="img-fluid img"
-													src="/website_freemoov/static/src/img/homepage/expert_advice1.png" />
+													src="/website_freemoov/static/src/img/homepage/expert_advice1.png"
+													alt="Guide d'achat trottinette"
+													width="192" height="183" loading="lazy" />
 												<a href="#" type="button" class="outline_btn">
 													<i class="fa fa-arrow-right text-white"></i>
 												</a>
@@ -371,8 +379,10 @@
 													parfaite pour vous !</h6>
 											</div>
 											<div class="expert_img">
-												<img class="img-fluid img "
-													src="/website_freemoov/static/src/img/homepage/expert_advice2.png" />
+												<img class="img-fluid img"
+													src="/website_freemoov/static/src/img/homepage/expert_advice2.png"
+													alt="Guide d'achat monoroue"
+													width="185" height="155" loading="lazy" />
 												<a href="#" type="button" class="outline_btn">
 													<i class="fa fa-arrow-right text-white"></i>
 												</a>
@@ -389,7 +399,9 @@
 											</div>
 											<div class="expert_img">
 												<img class="img-fluid img"
-													src="/website_freemoov/static/src/img/homepage/expert_advice3.png" />
+													src="/website_freemoov/static/src/img/homepage/expert_advice3.png"
+													alt="Astuces batterie"
+													width="185" height="152" loading="lazy" />
 												<a href="#" type="button" class="outline_btn">
 													<i class="fa fa-arrow-right text-white"></i>
 												</a>
@@ -405,7 +417,9 @@
 											</div>
 											<div class="expert_img">
 												<img class="img-fluid img"
-													src="/website_freemoov/static/src/img/homepage/expert_advice4.png" />
+													src="/website_freemoov/static/src/img/homepage/expert_advice4.png"
+													alt="Réglementation EDPM"
+													width="185" height="151" loading="lazy" />
 												<a href="#" type="button" class="outline_btn">
 													<i class="fa fa-arrow-right text-white"></i>
 												</a>


### PR DESCRIPTION
## Summary
- Add `font-display: swap` to feather.css font declarations (prevent invisible text during load)
- Add explicit `width`/`height` + `loading="lazy"` to all homepage images (prevent layout shifts)
- Add `min-height` to carousel items and UST product slider (reserve space before JS init)
- Bump to 16.0.0.1.5 with asset cache clear migration

## Context
Cloudflare Rocket Loader + cache rules already applied separately.
These code changes complement the CF optimizations to reduce CLS from 0.3+ to target < 0.1.

## Test plan
- [ ] Hard refresh freemoov.com after deploy
- [ ] Check CLS in Lighthouse/PageSpeed Insights
- [ ] Verify no visual regression on homepage