### PR TITLE
fix(payment_floa): seed account.payment.method to fix PML auto-create on enable

### DIFF
--- a/payment_floa/__manifest__.py
+++ b/payment_floa/__manifest__.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Payment Provider: FLOA Pay',
-    'version': '17.0.1.0.3',
+    'version': '17.0.1.0.4',
     'category': 'Accounting/Payment Providers',
     'summary': 'FLOA BNPL — Paiement en 3x pour la Belgique',
     'author': 'Freemoov',
     'website': 'https://freemoov.be',
     'depends': [
+        'account_payment',
         'payment',
         'website_sale',
         'website_freemoov',

--- a/payment_floa/data/payment_provider_data.xml
+++ b/payment_floa/data/payment_provider_data.xml
@@ -17,6 +17,18 @@
             <field name="image" type="base64" file="payment_floa/static/description/icon.png"/>
         </record>
 
+        <!--
+          Without this account.payment.method, payment_provider._ensure_payment_method_line()
+          returns silently and no account.payment.method.line is created when the provider is
+          enabled. The post-processing cron then keeps failing with "Please define a payment
+          method line on your payment." every time a FLOA transaction reaches state=done.
+        -->
+        <record id="account_payment_method_floa" model="account.payment.method">
+            <field name="name">FLOA Pay</field>
+            <field name="code">floa</field>
+            <field name="payment_type">inbound</field>
+        </record>
+
         <record id="payment_provider_floa" model="payment.provider">
             <field name="name">FLOA Pay — 3x sans frais</field>
             <field name="code">floa</field>


### PR DESCRIPTION
## Summary

- Adds `account.payment.method` (code=`floa`, type=`inbound`) seed so Odoo's `payment_provider._ensure_payment_method_line` actually creates the bank-journal `account.payment.method.line` when the provider is switched to enabled.
- Adds `account_payment` to `depends` so the model is guaranteed at install time.
- Bumps to 17.0.1.0.4.

## Context

Hit in production today on Charleroi's go-live. Cron `payment: post-process transactions` was looping every 10 min on transaction `S10235` (FLOA, €999, state=done) with:

> ValidationError: Please define a payment method line on your payment.

Root cause: without an `account.payment.method` rec with code='floa', `_ensure_payment_method_line()` returns at the `if not default_payment_method: return` guard, so no `account.payment.method.line` is ever created. `_create_payment` then fails the `_check_payment_method_line_id` constraint.

Production was patched live (PML id=25 created against journal 8 / provider 19, S10235 reconciled into account.payment id=2829). This PR pins the fix so staging and any fresh install don't reintroduce it.

## Test plan

- [ ] Fresh install of `payment_floa` on a clean v17 DB → check `account.payment.method` with code=`floa` exists
- [ ] Enable the provider in Settings > Payment Providers → check an `account.payment.method.line` is auto-created on the bank journal with `payment_provider_id` set
- [ ] Run a sandbox FLOA transaction to state=done → cron `payment: post-process transactions` creates the `account.payment` without raising